### PR TITLE
fix .ppflush method arg interface type hint in pprint-base

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -11,7 +11,7 @@
     clojure.spec.alpha
     clojure.core.specs.alpha
     clojure.main
-    #_clojure.pprint
+    clojure.pprint
     clojure.clr.io
     clojure.clr.shell
     clojure.core.protocols

--- a/src/stdlib/clojure/pprint/pprint_base.clj
+++ b/src/stdlib/clojure/pprint/pprint_base.clj
@@ -27,9 +27,9 @@
 ;;; constructs
 
 
-(def ^:dynamic 
- ^{:doc "Bind to true if you want write to use pretty printing", :added "1.2"}
- *print-pretty* true)
+(def ^:dynamic
+  ^{:doc "Bind to true if you want write to use pretty printing", :added "1.2"}
+  *print-pretty* true)
 
 (defonce ^:dynamic ; If folks have added stuff here, don't overwrite
  ^{:doc "The pretty print dispatch function. Use with-pprint-dispatch or set-pprint-dispatch
@@ -37,62 +37,62 @@ to modify.",
    :added "1.2"}
  *print-pprint-dispatch* nil)
 
-(def ^:dynamic 
- ^{:doc "Pretty printing will try to avoid anything going beyond this column.
-Set it to nil to have pprint let the line be arbitrarily long. This will ignore all 
+(def ^:dynamic
+  ^{:doc "Pretty printing will try to avoid anything going beyond this column.
+Set it to nil to have pprint let the line be arbitrarily long. This will ignore all
 non-mandatory newlines.",
-   :added "1.2"}
- *print-right-margin* 72)
+    :added "1.2"}
+  *print-right-margin* 72)
 
-(def ^:dynamic 
- ^{:doc "The column at which to enter miser style. Depending on the dispatch table, 
-miser style add newlines in more places to try to keep lines short allowing for further 
+(def ^:dynamic
+  ^{:doc "The column at which to enter miser style. Depending on the dispatch table,
+miser style add newlines in more places to try to keep lines short allowing for further
 levels of nesting.",
-   :added "1.2"}
- *print-miser-width* 40)
+    :added "1.2"}
+  *print-miser-width* 40)
 
 ;;; TODO implement output limiting
-(def ^:dynamic 
- ^{:private true,
-   :doc "Maximum number of lines to print in a pretty print instance (N.B. This is not yet used)"}
- *print-lines* nil)
+(def ^:dynamic
+  ^{:private true,
+    :doc "Maximum number of lines to print in a pretty print instance (N.B. This is not yet used)"}
+  *print-lines* nil)
 
 ;;; TODO: implement circle and shared
-(def ^:dynamic 
- ^{:private true,
-   :doc "Mark circular structures (N.B. This is not yet used)"}
- *print-circle* nil)
+(def ^:dynamic
+  ^{:private true,
+    :doc "Mark circular structures (N.B. This is not yet used)"}
+  *print-circle* nil)
 
 ;;; TODO: should we just use *print-dup* here?
-(def ^:dynamic 
- ^{:private true,
-   :doc "Mark repeated structures rather than repeat them (N.B. This is not yet used)"}
- *print-shared* nil)
+(def ^:dynamic
+  ^{:private true,
+    :doc "Mark repeated structures rather than repeat them (N.B. This is not yet used)"}
+  *print-shared* nil)
 
-(def ^:dynamic 
- ^{:doc "Don't print namespaces with symbols. This is particularly useful when 
+(def ^:dynamic
+  ^{:doc "Don't print namespaces with symbols. This is particularly useful when 
 pretty printing the results of macro expansions"
-   :added "1.2"}
- *print-suppress-namespaces* nil)
+    :added "1.2"}
+  *print-suppress-namespaces* nil)
 
 ;;; TODO: support print-base and print-radix in cl-format
 ;;; TODO: support print-base and print-radix in rationals
-(def ^:dynamic 
- ^{:doc "Print a radix specifier in front of integers and rationals. If *print-base* is 2, 8, 
+(def ^:dynamic
+  ^{:doc "Print a radix specifier in front of integers and rationals. If *print-base* is 2, 8, 
 or 16, then the radix specifier used is #b, #o, or #x, respectively. Otherwise the 
 radix specifier is in the form #XXr where XX is the decimal value of *print-base* "
-   :added "1.2"}
- *print-radix* nil)
+    :added "1.2"}
+  *print-radix* nil)
 
-(def ^:dynamic 
- ^{:doc "The base to use for printing integers and rationals."
-   :added "1.2"}
- *print-base* 10)
+(def ^:dynamic
+  ^{:doc "The base to use for printing integers and rationals."
+    :added "1.2"}
+  *print-base* 10)
 
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Internal variables that keep track of where we are in the 
+;; Internal variables that keep track of where we are in the
 ;; structure
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -143,16 +143,16 @@ radix specifier is in the form #XXr where XX is the decimal value of *print-base
         (finally
          (. clojure.lang.Var (popThreadBindings)))))))
 
-(defn- table-ize [t m] 
-  (apply hash-map (mapcat 
-                   #(when-let [v (get t (key %))] [(find-var v) (val %)]) 
+(defn- table-ize [t m]
+  (apply hash-map (mapcat
+                   #(when-let [v (get t (key %))] [(find-var v) (val %)])
                    m)))
 
-(defn- pretty-writer? 
+(defn- pretty-writer?
   "Return true iff x is a PrettyWriter"
   [x] (and (instance? clojure.lang.IDeref x) (:pretty-writer @@x)))
 
-(defn- make-pretty-writer 
+(defn- make-pretty-writer
   "Wrap base-writer in a PrettyWriter with the specified right-margin and miser-width"
   [base-writer right-margin miser-width]
   (pretty-writer base-writer right-margin miser-width))
@@ -161,27 +161,27 @@ radix specifier is in the form #XXr where XX is the decimal value of *print-base
   `(let [base-writer# ~base-writer
          new-writer# (not (pretty-writer? base-writer#))]
      (binding [*out* (if new-writer#
-                      (make-pretty-writer base-writer# *print-right-margin* *print-miser-width*)
-                      base-writer#)]
+                       (make-pretty-writer base-writer# *print-right-margin* *print-miser-width*)
+                       base-writer#)]
        ~@body
-       (.ppflush ^PrettyFlush *out*))))
+       (.ppflush ^clojure.pprint.PrettyFlush *out*))))
 
 
 ;;;TODO: if pretty print is not set, don't use pr but rather something that respects *print-base*, etc.
-(defn write-out 
-  "Write an object to *out* subject to the current bindings of the printer control 
-variables. Use the kw-args argument to override individual variables for this call (and 
-any recursive calls).
+(defn write-out
+  "Write an object to *out* subject to the current bindings of the printer control
+  variables. Use the kw-args argument to override individual variables for this call (and
+  any recursive calls).
 
-*out* must be a PrettyWriter if pretty printing is enabled. This is the responsibility
-of the caller.
+  *out* must be a PrettyWriter if pretty printing is enabled. This is the responsibility
+  of the caller.
 
-This method is primarily intended for use by pretty print dispatch functions that 
-already know that the pretty printer will have set up their environment appropriately.
-Normal library clients should use the standard \"write\" interface. "
+  This method is primarily intended for use by pretty print dispatch functions that
+  already know that the pretty printer will have set up their environment appropriately.
+  Normal library clients should use the standard \"write\" interface. "
   {:added "1.2"}
   [object]
-  (let [length-reached (and 
+  (let [length-reached (and
                         *current-length*
                         *print-length*
                         (>= *current-length* *print-length*))]
@@ -194,12 +194,12 @@ Normal library clients should use the standard \"write\" interface. "
           (*print-pprint-dispatch* object))))
     length-reached))
 
-(defn write 
+(defn write
   "Write an object subject to the current bindings of the printer control variables.
-Use the kw-args argument to override individual variables for this call (and any 
-recursive calls). Returns the string result if :stream is nil or nil otherwise.
+  Use the kw-args argument to override individual variables for this call (and any
+  recursive calls). Returns the string result if :stream is nil or nil otherwise.
 
-The following keyword arguments can be passed with values:
+  The following keyword arguments can be passed with values:
   Keyword              Meaning                              Default value
   :stream              Writer for output or nil             true (indicates *out*)
   :base                Base to use for writing rationals    Current value of *print-base*
@@ -216,54 +216,54 @@ The following keyword arguments can be passed with values:
   :suppress-namespaces If true, no namespaces in symbols    Current value of *print-suppress-namespaces*
 
   * = not yet supported
-"
+  "
   {:added "1.2"}
   [object & kw-args]
   (let [options (merge {:stream true} (apply hash-map kw-args))]
-    (binding-map (table-ize write-option-table options) 
-      (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {}) 
-        (let [optval (if (contains? options :stream) 
-                       (:stream options)
-                       true) 
-              base-writer (condp = optval
-                            nil (System.IO.StringWriter.)                    ;;; java.io.StringWriter.
-                            true *out*
-                            optval)]
-          (if *print-pretty*
-            (with-pretty-writer base-writer
-              (write-out object))
-            (binding [*out* base-writer]
-              (pr object)))
-          (if (nil? optval) 
-            (.ToString ^System.IO.StringWriter base-writer)))))))                        ;;; toString  java.io.StringWriter
+    (binding-map (table-ize write-option-table options)
+                 (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {})
+                              (let [optval (if (contains? options :stream)
+                                             (:stream options)
+                                             true)
+                                    base-writer (condp = optval
+                                                  nil (System.IO.StringWriter.)  ;;; java.io.StringWriter.
+                                                  true *out*
+                                                  optval)]
+                                (if *print-pretty*
+                                  (with-pretty-writer base-writer
+                                    (write-out object))
+                                  (binding [*out* base-writer]
+                                    (pr object)))
+                                (if (nil? optval)
+                                  (.ToString ^System.IO.StringWriter base-writer)))))))                        ;;; toString  java.io.StringWriter
 
 
-(defn pprint 
-  "Pretty print object to the optional output writer. If the writer is not provided, 
-print the object to the currently bound value of *out*."
+(defn pprint
+  "Pretty print object to the optional output writer. If the writer is not provided,
+  print the object to the currently bound value of *out*."
   {:added "1.2"}
-  ([object] (pprint object *out*)) 
+  ([object] (pprint object *out*))
   ([object writer]
-     (with-pretty-writer writer
-       (binding [*print-pretty* true]
-         (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {}) 
-           (write-out object)))
-       (if (not (= 0 (get-column *out*)))
-         (prn)))))
+   (with-pretty-writer writer
+     (binding [*print-pretty* true]
+       (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {})
+                    (write-out object)))
+     (if (not (= 0 (get-column *out*)))
+       (prn)))))
 
-(defmacro pp 
+(defmacro pp
   "A convenience macro that pretty prints the last thing output. This is
-exactly equivalent to (pprint *1)."
+  exactly equivalent to (pprint *1)."
   {:added "1.2"}
   [] `(pprint *1))
 
-(defn set-pprint-dispatch  
+(defn set-pprint-dispatch
   "Set the pretty print dispatch function to a function matching (fn [obj] ...)
-where obj is the object to pretty print. That function will be called with *out* set
-to a pretty printing writer to which it should do its printing.
+  where obj is the object to pretty print. That function will be called with *out* set
+  to a pretty printing writer to which it should do its printing.
 
-For example functions, see simple-dispatch and code-dispatch in 
-clojure.pprint.dispatch.clj."
+  For example functions, see simple-dispatch and code-dispatch in 
+  clojure.pprint.dispatch.clj."
   {:added "1.2"}
   [function]
   (let [old-meta (meta #'*print-pprint-dispatch*)]
@@ -271,7 +271,7 @@ clojure.pprint.dispatch.clj."
     (alter-meta! #'*print-pprint-dispatch* (constantly old-meta)))
   nil)
 
-(defmacro with-pprint-dispatch 
+(defmacro with-pprint-dispatch
   "Execute body with the pretty print dispatch function bound to function."
   {:added "1.2"}
   [function & body]
@@ -299,74 +299,74 @@ clojure.pprint.dispatch.clj."
 (defn- level-exceeded []
   (and *print-level* (>= *current-level* *print-level*)))
 
-(defmacro pprint-logical-block 
-  "Execute the body as a pretty printing logical block with output to *out* which 
-must be a pretty printing writer. When used from pprint or cl-format, this can be 
-assumed. 
+(defmacro pprint-logical-block
+  "Execute the body as a pretty printing logical block with output to *out* which
+  must be a pretty printing writer. When used from pprint or cl-format, this can be
+  assumed.
 
-This function is intended for use when writing custom dispatch functions.
+  This function is intended for use when writing custom dispatch functions.
 
-Before the body, the caller can optionally specify options: :prefix, :per-line-prefix, 
-and :suffix."
+  Before the body, the caller can optionally specify options: :prefix, :per-line-prefix,
+  and :suffix."
   {:added "1.2", :arglists '[[options* body]]}
   [& args]
   (let [[options body] (parse-lb-options #{:prefix :per-line-prefix :suffix} args)]
-    `(do (if (#'clojure.pprint/level-exceeded) 
+    `(do (if (#'clojure.pprint/level-exceeded)
            (.Write ^System.IO.TextWriter *out* "#")
-           (do 
+           (do
              (push-thread-bindings {#'clojure.pprint/*current-level*
                                     (inc (var-get #'clojure.pprint/*current-level*))
                                     #'clojure.pprint/*current-length* 0})
-             (try  
-              (#'clojure.pprint/start-block *out*
-                           ~(:prefix options) ~(:per-line-prefix options) ~(:suffix options))
-              ~@body
-              (#'clojure.pprint/end-block *out*)
-              (finally 
-               (pop-thread-bindings)))))
+             (try
+               (#'clojure.pprint/start-block *out*
+                                             ~(:prefix options) ~(:per-line-prefix options) ~(:suffix options))
+               ~@body
+               (#'clojure.pprint/end-block *out*)
+               (finally
+                 (pop-thread-bindings)))))
          nil)))
 
 (defn pprint-newline
-  "Print a conditional newline to a pretty printing stream. kind specifies if the 
-newline is :linear, :miser, :fill, or :mandatory. 
+  "Print a conditional newline to a pretty printing stream. kind specifies if the
+  newline is :linear, :miser, :fill, or :mandatory.
 
-This function is intended for use when writing custom dispatch functions.
+  This function is intended for use when writing custom dispatch functions.
 
-Output is sent to *out* which must be a pretty printing writer."
+  Output is sent to *out* which must be a pretty printing writer."
   {:added "1.2"}
-  [kind] 
+  [kind]
   (check-enumerated-arg kind #{:linear :miser :fill :mandatory})
   (nl *out* kind))
 
-(defn pprint-indent 
-  "Create an indent at this point in the pretty printing stream. This defines how 
-following lines are indented. relative-to can be either :block or :current depending 
-whether the indent should be computed relative to the start of the logical block or
-the current column position. n is an offset. 
+(defn pprint-indent
+  "Create an indent at this point in the pretty printing stream. This defines how
+  following lines are indented. relative-to can be either :block or :current depending
+  whether the indent should be computed relative to the start of the logical block or
+  the current column position. n is an offset.
 
-This function is intended for use when writing custom dispatch functions.
+  This function is intended for use when writing custom dispatch functions.
 
-Output is sent to *out* which must be a pretty printing writer."
+  Output is sent to *out* which must be a pretty printing writer."
   {:added "1.2"}
-  [relative-to n] 
+  [relative-to n]
   (check-enumerated-arg relative-to #{:block :current})
   (indent *out* relative-to n))
 
 ;; TODO a real implementation for pprint-tab
-(defn pprint-tab 
+(defn pprint-tab
   "Tab at this point in the pretty printing stream. kind specifies whether the tab
-is :line, :section, :line-relative, or :section-relative. 
+  is :line, :section, :line-relative, or :section-relative.
 
-Colnum and colinc specify the target column and the increment to move the target
-forward if the output is already past the original target.
+  Colnum and colinc specify the target column and the increment to move the target
+  forward if the output is already past the original target.
 
-This function is intended for use when writing custom dispatch functions.
+  This function is intended for use when writing custom dispatch functions.
 
-Output is sent to *out* which must be a pretty printing writer.
+  Output is sent to *out* which must be a pretty printing writer.
 
-THIS FUNCTION IS NOT YET IMPLEMENTED."
+  THIS FUNCTION IS NOT YET IMPLEMENTED."
   {:added "1.2"}
-  [kind colnum colinc] 
+  [kind colnum colinc]
   (check-enumerated-arg kind #{:line :section :line-relative :section-relative})
   (throw (NotImplementedException. "pprint-tab is not yet implemented")))            ;;; UnsupportedOperationException
 
@@ -379,18 +379,18 @@ THIS FUNCTION IS NOT YET IMPLEMENTED."
 
 (defn- pll-mod-body [var-sym body]
   (letfn [(inner [form]
-                 (if (seq? form)
-                   (let [form (macroexpand form)] 
-                     (condp = (first form)
-                       'loop* form
-                       'recur (concat `(recur (inc ~var-sym)) (rest form))
-                       (walk inner identity form)))
-                   form))]
+            (if (seq? form)
+              (let [form (macroexpand form)]
+                (condp = (first form)
+                  'loop* form
+                  'recur (concat `(recur (inc ~var-sym)) (rest form))
+                  (walk inner identity form)))
+              form))]
     (walk inner identity body)))
 
 (defmacro print-length-loop
   "A version of loop that iterates at most *print-length* times. This is designed 
-for use in pretty-printer dispatch functions."
+  for use in pretty-printer dispatch functions."
   {:added "1.3"}
   [bindings & body]
   (let [count-var (gensym "length-count")
@@ -398,6 +398,6 @@ for use in pretty-printer dispatch functions."
     `(loop ~(apply vector count-var 0 bindings)
        (if (or (not *print-length*) (< ~count-var *print-length*))
          (do ~@mod-body)
-         (.Write ^System.IO.TextWriter *out* "...")))))             ;;;; .write ^java.io.Writer 
+         (.Write ^System.IO.TextWriter *out* "...")))))             ;;;; .write ^java.io.Writer
 
 nil


### PR DESCRIPTION
close #13 

All the stdlib clojure files now compile.

We can now find the `clojure.pprint` dlls in the github artifact. 

Note : indent fix for `pprint-base` as well.