### PR TITLE
feat(nostrand): read deps-clr.edn and add built-in magic.edn build/test tasks

### DIFF
--- a/docs/clr-dependency-files.md
+++ b/docs/clr-dependency-files.md
@@ -1,0 +1,40 @@
+# Declaring CLR dependencies
+
+A library often needs different dependencies on the JVM and the CLR. `deps.edn` is EDN, so it cannot use reader conditionals to express that. There are two ways to carry the CLR-specific deps, and `nos` reads both.
+
+## The ClojureCLR way: `deps-clr.edn` (recommended)
+
+A separate file at the project root. `nos` reads it in place of `deps.edn` when it exists, and so does [ClojureCLR](https://github.com/clojure/clojure-clr)'s `cljr`, which reads `deps-clr.edn` first and falls back to `deps.edn` (see [clr.core.cli](https://github.com/clojure/clr.core.cli)). It is self-contained (its own `:paths` and `:deps`), and the JVM `deps.edn` stays untouched. This is ClojureCLR's own convention, so a library that uses it lines up with the wider CLR community's tooling and examples.
+
+```clojure
+;; deps-clr.edn
+{:paths ["src"]
+ :deps  {org.clojure/test.check {:git/url "https://github.com/flybot-sg/clr.test.check"
+                                 :git/sha "..."}}
+ :aliases {:test {:extra-paths ["test"]}}}
+```
+
+## The old way: a `:clr` alias
+
+One `deps.edn` with a `:clr` alias that adds or swaps deps for the CLR via `:extra-deps` and `:override-deps`, activated with `:nos/aliases [:clr]`. `nos` skips Maven coords, so a JVM dep left in `:deps` never resolves, and `:override-deps` points at the CLR fork wherever the lib appears, transitive deps included. Still supported: libraries already ported this way build unchanged. It suits CLR-native projects that are not published for the JVM.
+
+```clojure
+;; deps.edn
+{:paths ["src"]
+ :deps  {org.clojure/test.check {:mvn/version "1.1.1"}}
+ :aliases
+ {:clr  {:override-deps
+         {org.clojure/test.check {:git/url "https://github.com/flybot-sg/clr.test.check"
+                                  :git/sha "..."}}}
+  :test {:extra-paths ["test"]}}}
+```
+
+The `:clr` alias predates adopting the `deps-clr.edn` convention, so some libraries still use it.
+
+## How `nos` chooses
+
+`nos` uses `deps-clr.edn` if it exists in the project root, else `deps.edn`. The redirect is project-root only; transitive git and local deps still read their own `deps.edn`. The `nos`-specific keys `:nos/aliases` and `:nos/submodule-paths` are read from whichever file `nos` uses, so if you add a `deps-clr.edn`, move those keys into it.
+
+## See also
+
+[Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md) for the surrounding workflow.

--- a/docs/porting-libraries-to-magic.md
+++ b/docs/porting-libraries-to-magic.md
@@ -30,25 +30,7 @@ For the source patterns in depth (value-type and reference-type hints, records a
  :aliases {:test {:extra-paths ["test"]}}}
 ```
 
-### Swap JVM dependencies for CLR forks
-
-A dependency (yours or one pulled transitively) may be JVM-only on Maven, while a CLR fork of it exists as a git repo. `nos` skips Maven coords, so the JVM one never resolves; point at the fork with `:override-deps` under a `:clr` alias. `:override-deps` swaps a lib's coord wherever it appears in the tree, including transitive sightings, without adding it as a root dependency:
-
-```clojure
-{:paths ["src"]
- :deps  {org.clojure/test.check {:mvn/version "1.1.1"}}
- :aliases
- {:clr {:override-deps
-        {;; direct dep: use the MAGIC fork of test.check on the CLR
-         org.clojure/test.check {:git/url "https://github.com/flybot-sg/clr.test.check"
-                                 :git/sha "..."}
-         ;; transitive dep: a generated test asserts with matcho, whose JVM
-         ;; build is Maven-only; the flybot-sg fork is git
-         healthsamurai/matcho   {:git/url "https://github.com/flybot-sg/matcho"
-                                 :git/sha "..."}}}}}
-```
-
-The `:clr` alias does nothing until activated. Add `:nos/aliases [:clr]` at the top level of `deps.edn`; `nos` applies it at boot, so the override is in effect for every task.
+When a library needs CLR-specific dependencies (a CLR fork of a JVM library, for instance), declare them in a `deps-clr.edn`. See [Declaring CLR dependencies](./clr-dependency-files.md).
 
 ## 3. dotnet.clj
 

--- a/docs/porting-libraries-to-magic.md
+++ b/docs/porting-libraries-to-magic.md
@@ -2,7 +2,7 @@
 
 How to take an existing Clojure library and compile and test it on the CLR with MAGIC. Assumes `nos` is installed (see the [Install](../README.md#install) section).
 
-The work is in three parts: make the source cross-platform, declare paths and deps in `deps.edn`, and add a `dotnet.clj` with build and test tasks.
+The work is in three parts: make the source cross-platform, declare paths and deps in `deps.edn`, and configure build and test in `magic.edn`.
 
 ## 1. Make the source cross-platform
 
@@ -32,100 +32,78 @@ For the source patterns in depth (value-type and reference-type hints, records a
 
 When a library needs CLR-specific dependencies (a CLR fork of a JVM library, for instance), declare them in a `deps-clr.edn`. See [Declaring CLR dependencies](./clr-dependency-files.md).
 
-## 3. dotnet.clj
+## 3. magic.edn
 
-Put a `dotnet.clj` at the project root. `nostrand.tasks` provides the build and test tasks, so a project only states what is specific to it. Pick one of the three shapes below.
-
-### Derive namespaces from deps.edn (recommended)
-
-With no explicit list, the namespaces are read off the source paths the given aliases contribute. `build` compiles the base `:paths`; `run-tests` adds the `:test` alias paths:
+`nos` has built-in `build` and `test` tasks. They read an optional `magic.edn` at the project root: a map with `:build` and `:test` option sub-maps. A project states only what differs from the defaults, so most `magic.edn` files are a few lines, and a project that needs no tweaks can omit the file entirely.
 
 ```clojure
-(ns dotnet
-  (:require [nostrand.tasks :as tasks]))
-
-(defn build     [] (tasks/compile-project :clean? true))
-(defn run-tests [] (tasks/run-clojure-tests :aliases [:test]))
-```
-
-### Exclude namespaces that must not load on the CLR
-
-A source tree often carries namespaces that cannot load under MAGIC (a ClojureScript-only namespace, JVM-only test tooling). Keep deriving and drop them with `:exclude`:
-
-```clojure
-(ns dotnet
-  (:require [nostrand.tasks :as tasks]))
-
-(def cljs-only
-  '[my.lib.frontend.cljs])
-
-(defn build     [] (tasks/compile-project :exclude cljs-only))
-(defn run-tests [] (tasks/run-clojure-tests :aliases [:test] :exclude cljs-only))
-```
-
-### Hardcode the namespace list
-
-When you want exact control (a single compile root, a vendored namespace not reachable by `require`, or a test dir where naming the few real suites is clearer than excluding the rest), pass `:namespaces`:
-
-```clojure
-(ns dotnet
-  (:require [nostrand.tasks :as tasks]))
-
-(def prod-namespaces '[my.lib.core my.lib.api])
-(def test-namespaces '[my.lib.core-test my.lib.api-test])
-
-(defn build     [] (tasks/compile-project :namespaces prod-namespaces))
-(defn run-tests [] (tasks/run-clojure-tests
-                    :namespaces (concat prod-namespaces test-namespaces)
-                    :aliases    [:test]))
-```
-
-### Scope the run to your own suites
-
-`run-clojure-tests` runs every `clojure.test` suite loaded in the runtime, so requiring your test namespaces can pull in suites belonging to your dependencies. Pass `:re` to limit the run to namespaces the regex fully matches (`run-all-tests` filters with `re-matches`, so match the whole name, not a substring):
-
-```clojure
-(defn run-tests [] (tasks/run-clojure-tests :aliases [:test] :re #"my\.lib\..*"))
+;; magic.edn
+{:build {:aliases [:clr]}
+ :test  {:aliases [:clr :test]}}
 ```
 
 ### Options
 
-| Option        | `compile-project` | `run-clojure-tests` | Meaning                                                        |
-|---------------|:-----------------:|:-------------------:|----------------------------------------------------------------|
-| `:namespaces` | yes               | yes                 | Explicit namespaces, overrides derivation                      |
-| `:exclude`    | yes               | yes                 | Namespaces to drop from the derived (or explicit) set          |
-| `:re`         | no                | yes                 | Regex a namespace must fully match to be run                   |
-| `:aliases`    | yes               | yes                 | deps.edn aliases to activate, e.g. `[:test]`                   |
-| `:flags`      | yes               | yes                 | `var->value` binding map (default `tasks/production-flags`)    |
-| `:out`        | yes               | no                  | `*compile-path*` (default `"build"`)                           |
-| `:clean?`     | yes               | no                  | Wipe `:out` first (Unity dirs that must not keep stale DLLs)   |
-| `:exit?`      | no                | yes                 | `Environment/Exit 1` on any failure or error (default true)    |
+| Key | build | test | Meaning | Default |
+|-----|:-:|:-:|---|---|
+| `:aliases`    | yes | yes | deps aliases to activate | none (test: `[:test]`) |
+| `:namespaces` | yes | yes | explicit namespaces, overrides derivation | derived from paths |
+| `:exclude`    | yes | yes | namespaces to drop from the set | none |
+| `:re`         |     | yes | regex scoping the run (`re-matches`) | the project's own namespaces |
+| `:flags`      | yes | yes | flag overrides (see below) | build: production, test: test-friendly |
+| `:out`        | yes |     | compile output dir | `"build"` |
+| `:clean?`     | yes |     | wipe `:out` first | `true` |
 
-`tasks/production-flags` is the flag set shipped projects compile under (`*direct-linking*`, `*strongly-typed-invokes*`, `*elide-meta*`, `*unchecked-math*`, `*warn-on-reflection*`). It is a plain map, so a test run that needs redefinable vars overrides it:
+With no `:namespaces`, the set is derived from the source paths the aliases contribute (the base `:paths` for build, plus the test alias's `:extra-paths` for test). With no `:re`, a test run is scoped to the project's own namespaces, so its suites run and its dependencies' bundled suites do not.
+
+### Flags
+
+`:flags` overrides the compilation flags for the run. EDN cannot hold a var, so name each flag as a fully-qualified symbol:
+
+```clojure
+{:build {:flags {magic.flags/*elide-meta* true}}}
+```
+
+`build` starts from the production flag set (`*direct-linking*`, `*strongly-typed-invokes*`, `*elide-meta*`, `*unchecked-math*`, `*warn-on-reflection*`). `test` starts from the same set with `*direct-linking*` and `*strongly-typed-invokes*` off, since `with-redefs` cannot rebind a direct-linked or strongly-typed call. Your `:flags` merge over that base, so state only what you change.
+
+### More examples
+
+Exclude a namespace that must not compile on the CLR (a ClojureScript-only or JVM-only one):
+
+```clojure
+{:build {:exclude [my.lib.frontend.cljs]}
+ :test  {:exclude [my.lib.frontend.cljs]}}
+```
+
+State the compile roots and output directory explicitly (a Unity plugins build, or a vendored namespace not reachable by `require`):
+
+```clojure
+{:build {:namespaces [my.lib.core my.lib.api]
+         :out        "Assets/Plugins/Magic"}}
+```
+
+### The old way: dotnet.clj
+
+Before the built-in tasks, each project wrote a `dotnet.clj` defining `build`/`run-tests` by hand over `nostrand.tasks`. It stays backward compatible: existing `dotnet.clj` files still work unchanged, and `nos dotnet/build` and `nos build` coexist.
 
 ```clojure
 (ns dotnet
-  (:require [magic.flags :as mflags]
-            [nostrand.tasks :as tasks]))
+  (:require [nostrand.tasks :as tasks]))
 
-(defn run-tests []
-  (tasks/run-clojure-tests
-   :aliases [:test]
-   :flags   (assoc tasks/production-flags
-                   #'mflags/*direct-linking*         false
-                   #'mflags/*strongly-typed-invokes* false)))
+(defn build     [] (tasks/compile-project :aliases [:clr] :clean? true))
+(defn run-tests [] (tasks/run-clojure-tests :aliases [:clr :test]))
 ```
+
+`magic.edn` exposes the full option set of both tasks, so a ported library needs no `dotnet.clj`; write one only for a project that also defines its own unrelated `nos` tasks.
 
 ## 4. Build and test
 
 ```bash
-nos dotnet/build        # compiles to ./build (or :out)
-nos dotnet/run-tests    # requires the namespaces, runs clojure.test, exits non-zero on failure
+nos build    # compiles to ./build (or :out)
+nos test     # runs the project's clojure.test suites, exits non-zero on failure
 ```
 
-`run-tests` executes under Mono and does not cover IL2CPP codegen; for Unity, an actual IL2CPP build is the only way to catch AOT-only regressions (see [`magic-unity-smoke`](../unity-examples/magic-unity-smoke)).
-
-`:clean? true` wipes the output dir before compiling, so the task does not need a `rm -rf build` shell step in front of it.
+`nos test` runs under Mono and does not cover IL2CPP codegen; for Unity, an actual IL2CPP build is the only way to catch AOT-only regressions (see [`magic-unity-smoke`](../unity-examples/magic-unity-smoke)).
 
 ## 5. CI
 
@@ -152,21 +130,15 @@ Use an absolute path (`$CI_PROJECT_DIR`-based, not a bare relative one): a relat
 
 If a library's tests are written as [rich comment tests](https://github.com/robertluo/rich-comment-tests) (RCT), they cannot run on the CLR as-is: RCT extracts assertions at runtime using `rewrite-clj` and other JVM-only machinery. [flybot-sg/rct-clr](https://github.com/flybot-sg/rct-clr) bridges this: on the JVM it reads the rich comments and emits a plain `.cljc` test file of ordinary `deftest` forms that assert with [matcho](https://github.com/flybot-sg/matcho). MAGIC then runs that generated file with just `clojure.test` and `matcho.core`.
 
-The split shows up in `dotnet.clj`: test only the generated namespace and leave the RCT source out, since it would drag the JVM-only tooling in. `matcho` is the one extra runtime dependency, supplied by the `:clr` override above:
+The split shows up in `magic.edn`: `:exclude` the RCT source namespace (the rich comments plus the JVM-only extraction tooling), leaving the generated `deftest` namespace to run like any other suite. `matcho` is the one extra runtime dependency, from `deps-clr.edn`:
 
 ```clojure
-(def test-namespaces
-  ;; the generated deftests; the RCT source ns (rich comments) stays JVM-only
-  '[my.lib.generated-test])
-
-(defn run-tests []
-  (tasks/run-clojure-tests
-   :namespaces (concat prod-namespaces test-namespaces)
-   :aliases    [:clr :test]))
+{:test {:aliases [:clr :test]
+        :exclude [my.lib.rct-test]}}
 ```
 
 The `clojure.test` assertion count on the CLR will not be one-for-one with a JVM run that executes the rich comments directly: RCT and the generated `deftest`s tally assertions differently (one `=>` expectation can expand to several matcho checks). The count differs; the same expectations are all verified.
 
 ## Reference
 
-[flybot-sg/clr.test.check](https://github.com/flybot-sg/clr.test.check) is a fork of `clojure/test.check` ported with this workflow: reader conditionals throughout, and a `dotnet.clj` that derives its namespaces from `deps.edn`.
+[flybot-sg/clr.test.check](https://github.com/flybot-sg/clr.test.check) is a fork of `clojure/test.check` ported with this workflow: reader conditionals throughout, cross-platform `deps.edn`, and CLR tests run under `nos`.

--- a/nostrand/Nostrand.cs
+++ b/nostrand/Nostrand.cs
@@ -136,7 +136,7 @@ namespace Nostrand
 
 				RT.var("nostrand.core", "load-path").invoke(Directory.GetCurrentDirectory());
 				
-				if (File.Exists("deps.edn"))
+				if (File.Exists("deps.edn") || File.Exists("deps-clr.edn"))
 				{
 					RT.var("nostrand.core", "establish-deps-edn").invoke();
 				}

--- a/nostrand/nostrand/core.clj
+++ b/nostrand/nostrand/core.clj
@@ -73,8 +73,9 @@
   the vendored git submodules (its value is a path prefix to restrict to,
   or true for every submodule)."
   ([]
-   (let [deps-edn (edn/read-string (slurp "deps.edn"))
-         b        (establish-deps-edn "deps.edn" (:nos/aliases deps-edn []))]
+   (let [deps-file (basis/project-deps-file)
+         deps-edn  (edn/read-string (slurp deps-file))
+         b         (establish-deps-edn deps-file (:nos/aliases deps-edn []))]
      (when-let [root (:nos/submodule-paths deps-edn)]
        (when (File/Exists ".gitmodules")
          (apply load-path

--- a/nostrand/nostrand/deps/basis.clj
+++ b/nostrand/nostrand/deps/basis.clj
@@ -108,10 +108,17 @@
     (str gitlibs "/nostrand")
     (str (Environment/GetEnvironmentVariable "HOME") "/.nostrand/gitlibs")))
 
+(defn project-deps-file
+  "deps-clr.edn if present, else deps.edn. Matches cljr, which reads
+  deps-clr.edn in place of deps.edn. Project root only; transitive deps keep
+  their own deps.edn."
+  []
+  (if (File/Exists "deps-clr.edn") "deps-clr.edn" "deps.edn"))
+
 (defn create-basis
   "Read deps-file, fold in the selected aliases, resolve transitively,
   and return {:paths :libs :classpath-paths}."
-  ([] (create-basis "deps.edn" []))
+  ([] (create-basis (project-deps-file) []))
   ([deps-file aliases]
    (let [{:keys [paths deps overrides]} (merge-aliases (edn/read-string (slurp deps-file)) aliases)
          libs (resolve-deps (cache-root) deps overrides)]

--- a/nostrand/nostrand/tasks.clj
+++ b/nostrand/nostrand/tasks.clj
@@ -2,6 +2,7 @@
  ^{:author "Ramsey Nasser"
    :doc    "Built in nostrand tasks, available from the command line as unqualified functions"}
  nostrand.tasks
+  (:refer-clojure :exclude [test])
   (:import
    [Nostrand Nostrand]
    [System.IO Directory File]
@@ -13,10 +14,11 @@
             [nostrand.deps.basis :as basis]
             [nostrand.deps.submodules :as submodules]
             [magic.flags :as mflags]
+            [clojure.edn :as edn]
             [clojure.string :as string]
             [clojure.pprint :as pprint]
             [clojure.core.server :as clj-server]
-            [clojure.test :as test]
+            [clojure.test :as ct]
             clojure.repl))
 
 (defn- msg
@@ -130,15 +132,21 @@
 (def production-flags
   "The compilation flags shipped MAGIC projects build under, as a var->value
   map ready for `clojure.core/with-bindings` or the `:flags` option of
-  `compile-project` / `run-clojure-tests`. Kept open on purpose: a task that
-  needs to deviate assoc's onto it (test runs that rely on redefinable vars
-  set :direct-linking and :strongly-typed-invokes false), or passes its own
-  map. Shared so consumer dotnet.clj tasks do not each restate the set."
+  `compile-project` / `run-clojure-tests`. A plain map, so a task that needs
+  to deviate assoc's onto it or passes its own (see `test-flags`). Shared so
+  consumer dotnet.clj tasks do not each restate the set."
   {#'*unchecked-math*                true
    #'*warn-on-reflection*            true
    #'mflags/*strongly-typed-invokes* true
    #'mflags/*direct-linking*         true
    #'mflags/*elide-meta*             false})
+
+(def test-flags
+  "production-flags with direct-linking and strongly-typed-invokes off, so
+  with-redefs can rebind calls in tests."
+  (assoc production-flags
+         #'mflags/*direct-linking*         false
+         #'mflags/*strongly-typed-invokes* false))
 
 (defn- file-namespace
   "The namespace a Clojure source file declares, or nil if its first form is
@@ -219,8 +227,9 @@
     :namespaces  explicit namespaces to require (overrides derivation)
     :exclude     namespaces to drop from the set
     :re          regex limiting the run to namespaces it fully matches
-                 (`run-all-tests` uses `re-matches`), e.g. #\"flybot\\..*\"
-                 (default: every loaded suite)
+                 (`run-all-tests` uses `re-matches`), e.g. #\"flybot\\..*\".
+                 Without it the run is scoped to the derived namespaces, so a
+                 project's own suites run and its dependencies' do not.
     :aliases     deps.edn aliases to activate, e.g. [:clr :test] (so the test
                  source paths land on the load path before `require`)
     :flags       var->value binding map (default `production-flags`)
@@ -236,9 +245,52 @@
     (with-bindings flags
       (doseq [ns nses]
         (require ns))
-      (let [{:keys [fail error] :as summary} (if re
-                                               (test/run-all-tests re)
-                                               (test/run-all-tests))]
+      (let [{:keys [fail error] :as summary} (cond
+                                               re         (ct/run-all-tests re)
+                                               (seq nses) (apply ct/run-tests nses)
+                                               :else      (ct/run-all-tests))]
         (when (and exit? (or (pos? fail) (pos? error)))
           (Environment/Exit 1))
         summary))))
+
+(defn- read-magic-edn
+  "The project's magic.edn as a map, or nil when the file is absent."
+  []
+  (when (File/Exists "magic.edn")
+    (edn/read-string (slurp "magic.edn"))))
+
+(defn- resolve-flags
+  "Fold a {fully-qualified-symbol value} flag map over `base`, resolving each
+  symbol to its var (its namespace is required first)."
+  [base flags]
+  (reduce-kv (fn [m sym v]
+               (require (symbol (namespace sym)))
+               (assoc m (resolve sym) v))
+             base
+             flags))
+
+(defn build
+  "Compile the project under MAGIC, per magic.edn :build. Run as `nos build`."
+  []
+  (let [{:keys [aliases namespaces exclude out clean? flags]
+         :or   {out "build" clean? true}}
+        (:build (read-magic-edn))]
+    (compile-project :aliases    (vec aliases)
+                     :namespaces namespaces
+                     :exclude    exclude
+                     :out        out
+                     :clean?     clean?
+                     :flags      (resolve-flags production-flags flags))))
+
+(defn test
+  "Run the project's clojure.test suites under MAGIC, per magic.edn :test.
+  Run as `nos test`."
+  []
+  (let [{:keys [aliases namespaces exclude re flags]
+         :or   {aliases [:test]}}
+        (:test (read-magic-edn))]
+    (run-clojure-tests :aliases    (vec aliases)
+                       :namespaces namespaces
+                       :exclude    exclude
+                       :re         (some-> re re-pattern)
+                       :flags      (resolve-flags test-flags flags))))

--- a/nostrand/nostrand/tasks.clj
+++ b/nostrand/nostrand/tasks.clj
@@ -86,7 +86,7 @@
   Usage: nos print-basis            ; base :deps only
          nos print-basis :clr :test ; with aliases"
   [& aliases]
-  (let [{:keys [paths libs classpath-paths]} (basis/create-basis "deps.edn" (vec aliases))]
+  (let [{:keys [paths libs classpath-paths]} (basis/create-basis (basis/project-deps-file) (vec aliases))]
     (pprint/pprint
      {:aliases         (vec aliases)
       :paths           paths
@@ -169,7 +169,7 @@
   compile or test instead of hand-listing it. Read-only; does not touch the
   load path.
       (tasks/project-namespaces [:test])"
-  ([aliases] (project-namespaces "deps.edn" aliases))
+  ([aliases] (project-namespaces (basis/project-deps-file) aliases))
   ([deps-file aliases]
    (paths-namespaces (:paths (basis/create-basis deps-file (vec aliases))))))
 
@@ -180,7 +180,7 @@
   namespaces from either source (e.g. test-dir tooling that must not load)."
   [namespaces aliases exclude basis]
   (->> (or namespaces
-           (paths-namespaces (:paths (or basis (basis/create-basis "deps.edn" (vec aliases))))))
+           (paths-namespaces (:paths (or basis (basis/create-basis (basis/project-deps-file) (vec aliases))))))
        (remove (set exclude))))
 
 (defn compile-project
@@ -199,7 +199,7 @@
       (defn build [] (tasks/compile-project :aliases [:clr]))"
   [& {:keys [namespaces exclude aliases out clean? flags]
       :or   {out "build" clean? false flags production-flags}}]
-  (let [basis (when (seq aliases) (nos/establish-deps-edn "deps.edn" aliases))
+  (let [basis (when (seq aliases) (nos/establish-deps-edn (basis/project-deps-file) aliases))
         nses  (task-namespaces namespaces aliases exclude basis)]
     (with-bindings (assoc flags #'*compile-path* out)
       (println "Compiling into DLL dir:" *compile-path*)
@@ -231,7 +231,7 @@
       (defn run-tests [] (tasks/run-clojure-tests :aliases [:clr :test]))"
   [& {:keys [namespaces exclude re aliases flags exit?]
       :or   {flags production-flags exit? true}}]
-  (let [basis (when (seq aliases) (nos/establish-deps-edn "deps.edn" aliases))
+  (let [basis (when (seq aliases) (nos/establish-deps-edn (basis/project-deps-file) aliases))
         nses  (task-namespaces namespaces aliases exclude basis)]
     (with-bindings flags
       (doseq [ns nses]


### PR DESCRIPTION
Closes #35, closes #36
---

- Resolve deps from `deps-clr.edn` when present, else `deps.edn`, matching cljr (project root only; transitive deps keep their own `deps.edn`)
- Add built-in `nos build` / `nos test` reading an optional `magic.edn`, so a ported library needs no hand-written `dotnet.clj`
- `nos test` defaults to the project's own namespaces, with direct-linking and strongly-typed-invokes off so `with-redefs` works
- Document `deps-clr.edn` and `magic.edn`; rewrite the porting guide around them
