### PR TITLE
fix(nostrand): nil-safe alias selection, warn on undeclared aliases

### DIFF
--- a/nostrand/nostrand/core.clj
+++ b/nostrand/nostrand/core.clj
@@ -2,8 +2,7 @@
     ^{:author "Ramsey Nasser"
       :doc "Core nostrand API containing load path, assemblies, and dependency functions."}
     nostrand.core
-  (:require [clojure.edn :as edn]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [nostrand.deps.basis :as basis]
             [nostrand.deps.submodules :as submodules])
   (:import [System.IO Path File]))
@@ -74,7 +73,7 @@
   or true for every submodule)."
   ([]
    (let [deps-file (basis/project-deps-file)
-         deps-edn  (edn/read-string (slurp deps-file))
+         deps-edn  (basis/read-project-deps deps-file)
          b         (establish-deps-edn deps-file (:nos/aliases deps-edn []))]
      (when-let [root (:nos/submodule-paths deps-edn)]
        (when (File/Exists ".gitmodules")

--- a/nostrand/nostrand/deps/basis.clj
+++ b/nostrand/nostrand/deps/basis.clj
@@ -50,7 +50,7 @@
   repo has no deps.edn or a non-src layout, e.g. a pom-only contrib lib under
   src/main/clojure), else the lib's own deps.edn :paths, else [\"src\"]."
   [dir coord lib-deps-edn]
-  (map #(str dir "/" %) (or (:paths coord) (:paths lib-deps-edn) ["src"])))
+  (map #(str dir "/" %) (or (:paths coord) (:paths lib-deps-edn) default-paths)))
 
 (defn- read-deps-edn [dir]
   (let [f (str dir "/deps.edn")]
@@ -90,8 +90,8 @@
           (let [kept (:resolved-sha (out lib))
                 cur  (or (:git/sha coord) (:git/tag coord))]
             (when (and kept cur (not (git/same-commit? kept cur)))
-              (println "WARN: conflicting version for" lib
-                       "-> kept" kept "ignored" cur))
+              (printerrln "WARN: conflicting version for" lib
+                          "-> kept" kept "ignored" cur))
             (recur more out skipped))
 
           (not (native-coord? coord))
@@ -107,8 +107,8 @@
                    skipped))))
       (do
         (when (seq skipped)
-          (println "Note: skipped" (count skipped) "non-native (maven) dep(s):"
-                   (str/join ", " skipped)))
+          (printerrln "Note: skipped" (count skipped) "non-native (maven) dep(s):"
+                      (str/join ", " skipped)))
         out))))
 
 (defn- cache-root
@@ -127,12 +127,24 @@
   []
   (if (File/Exists "deps-clr.edn") "deps-clr.edn" "deps.edn"))
 
+(defn read-project-deps
+  "Parse the project deps file, naming it in the error when it is missing
+  or malformed (a bare slurp/reader failure names neither)."
+  [deps-file]
+  (when-not (File/Exists deps-file)
+    (throw (ex-info (str "Deps file not found: " deps-file) {:file deps-file})))
+  (try
+    (edn/read-string (slurp deps-file))
+    (catch Exception e
+      (throw (ex-info (str "Malformed " deps-file ": " (.Message e))
+                      {:file deps-file} e)))))
+
 (defn create-basis
   "Read deps-file, fold in the selected aliases, resolve transitively,
   and return {:paths :libs :classpath-paths}."
   ([] (create-basis (project-deps-file) []))
   ([deps-file aliases]
-   (let [{:keys [paths deps overrides]} (merge-aliases (edn/read-string (slurp deps-file)) aliases)
+   (let [{:keys [paths deps overrides]} (merge-aliases (read-project-deps deps-file) aliases)
          libs (resolve-deps (cache-root) deps overrides)]
      {:paths paths
       :libs  libs

--- a/nostrand/nostrand/deps/basis.clj
+++ b/nostrand/nostrand/deps/basis.clj
@@ -4,6 +4,14 @@
             [clojure.string :as str]
             [nostrand.deps.git :as git]))
 
+(def ^:private default-paths ["src"])
+
+(defn- printerrln
+  "println to stderr, keeping stdout clean for task output."
+  [& args]
+  (binding [*out* *err*]
+    (apply println args)))
+
 (def ^:private runtime-provided
   "Libs that ship inside Clojure.dll, so they are never resolved."
   '#{org.clojure/clojure
@@ -25,10 +33,14 @@
   "Fold the selected aliases into {:paths :deps :overrides}. :extra-paths
   append to :paths; :extra-deps merge onto the dep set; :override-deps are
   kept separate (an override swaps a lib's coord wherever it is encountered
-  in the tree, without itself seeding a root dependency)."
+  in the tree, without itself seeding a root dependency). Selected keywords
+  not declared under :aliases warn and are skipped, matching tools.deps."
   [{:keys [paths deps aliases]} alias-kws]
-  (let [selected (map aliases alias-kws)]
-    {:paths     (into (vec (or paths ["src"])) (mapcat :extra-paths selected))
+  (when-let [undeclared (seq (remove #(contains? aliases %) (distinct alias-kws)))]
+    (printerrln "WARNING: Specified aliases are undeclared and are not being used:"
+                (vec undeclared)))
+  (let [selected (keep #(get aliases %) alias-kws)]
+    {:paths     (into (vec (or paths default-paths)) (mapcat :extra-paths selected))
      :deps      (apply merge deps (map :extra-deps selected))
      :overrides (apply merge (map :override-deps selected))}))
 


### PR DESCRIPTION
Closes #55
---

- `merge-aliases` invoked the possibly-absent `:aliases` map as the lookup fn, so a `deps.edn` without `:aliases` crashed alias selection with a bare `NullReferenceException`, and undeclared alias keywords were silently dropped. Alias lookup is now nil-safe (`get`), and undeclared aliases warn on stderr with the tools.deps CLI message, warning rather than throwing for parity with the Clojure CLI.
- Follow-up diagnostics cleanup: `read-project-deps` names the deps file in missing/malformed read errors; dependency-resolution warnings (conflicting version, skipped maven deps) move from stdout to stderr so `print-basis` output stays machine-parseable; the duplicated `["src"]` default becomes one def.