### PR TITLE
feat(nostrand): add nos where task printing the runtime dir

### DIFF
--- a/docs/native-assemblies.md
+++ b/docs/native-assemblies.md
@@ -57,6 +57,14 @@ Keeping the load in the require graph is what makes it work everywhere, with no 
 
 A library that must build on both stock ClojureCLR and MAGIC should pair the loader with a self-contained `deps-clr.edn` whose `:paths` include the DLL directory. Both `cljr` and `nos` read that one file and put every `:paths` entry on `CLOJURE_LOAD_PATH`, so the loader's scan finds the assembly on either runtime. See [Declaring CLR dependencies](./clr-dependency-files.md).
 
+## Building the assembly against the runtime
+
+When the C# source references Clojure types, the compiler needs the runtime assemblies. `nos where` prints the directory the running host loaded them from, so a build script never guesses install dirs:
+
+```bash
+csc -deterministic -target:library -r:$(nos where Clojure.dll) -out:src_classes/my_interop.dll MyInterop.cs
+```
+
 ## See also
 
 - [Declaring CLR dependencies](./clr-dependency-files.md)

--- a/nostrand/README.md
+++ b/nostrand/README.md
@@ -38,6 +38,12 @@ Clojure 1.10.0-master-SNAPSHOT
 
 $ nos repl
 user=>
+
+$ nos where
+/Users/me/.local/nostrand/net471
+
+$ nos where Clojure.dll
+/Users/me/.local/nostrand/net471/Clojure.dll
 ```
 
 With a namespace they are searched for using Clojure's normal namespace resolution machinery. The current directory is on the load path by default.

--- a/nostrand/nostrand/tasks.clj
+++ b/nostrand/nostrand/tasks.clj
@@ -5,7 +5,7 @@
   (:refer-clojure :exclude [test])
   (:import
    [Nostrand Nostrand]
-   [System.IO Directory File]
+   [System.IO Directory File Path]
    [System.Threading Thread ThreadStart]
    [System.Reflection AssemblyInformationalVersionAttribute])
   (:require [nostrand.repl :as repl]
@@ -36,6 +36,15 @@
   (msg "Runtime" (str (Environment/get_Version)
                       " (" (Environment/get_OSVersion) ")")
        ConsoleColor/DarkGray))
+
+(defn where
+  "Print the directory the running host loaded Clojure.dll from, as bare
+  stdout for shell capture. With a file name, print that file's full path.
+  Usage: nos where                  ; the runtime assemblies dir
+         nos where Clojure.dll      ; full path of one assembly"
+  ([] (println (-> (.Assembly clojure.lang.RT) .Location Path/GetDirectoryName)))
+  ([file] (println (Path/Combine (-> (.Assembly clojure.lang.RT) .Location Path/GetDirectoryName)
+                                 (str file)))))
 
 (defn cli-repl
   ([] (cli-repl nil))


### PR DESCRIPTION
Closes #72
---

- `nos where` prints the directory the host loaded `Clojure.dll` from, `nos where <file>` prints that file's full path, both as bare stdout for `$(...)` capture
- Documents the `csc -r:$(nos where Clojure.dll)` pattern in `docs/native-assemblies.md`