### PR TITLE
fix(tooling): include release tags in the DLL SourceRevisionId stamp

### DIFF
--- a/clojure-runtime/Clojure.csproj
+++ b/clojure-runtime/Clojure.csproj
@@ -8,7 +8,7 @@
 
     <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation">
     <Exec 
-      Command="git describe --long --always --dirty --exclude=* --abbrev=8"
+      Command="git describe --tags --long --always --dirty --match='v*' --abbrev=8"
       StandardOutputImportance="low"
       ConsoleToMSBuild="True"
       IgnoreExitCode="False"

--- a/magic-runtime/Magic.Runtime/Magic.Runtime.csproj
+++ b/magic-runtime/Magic.Runtime/Magic.Runtime.csproj
@@ -15,7 +15,7 @@
 
   <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation">
     <Exec 
-      Command="git describe --long --always --exclude=* --abbrev=8"
+      Command="git describe --tags --long --always --match='v*' --abbrev=8"
       StandardOutputImportance="low"
       ConsoleToMSBuild="True"
       IgnoreExitCode="False"

--- a/nostrand/NostrandMain.csproj
+++ b/nostrand/NostrandMain.csproj
@@ -30,7 +30,7 @@
 
   <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation">
     <Exec 
-      Command="git describe --long --always --exclude=* --abbrev=8"
+      Command="git describe --tags --long --always --match='v*' --abbrev=8"
       StandardOutputImportance="low"
       ConsoleToMSBuild="True"
       IgnoreExitCode="False"


### PR DESCRIPTION
Closes #75
---
- Replace `--exclude=*` with `--tags --match='v*'` in the three `git describe` stamp commands (`Clojure.csproj`, `Magic.Runtime.csproj`, `NostrandMain.csproj`).
- Verified at a v0.10.0 worktree the stamp becomes `0.10.0+v0.10.0-0-g1fd8e08d`, while a develop build keeps the bare commit hash since release tags are only reachable from `main`.
- `--tags` is needed because the release workflow checkout stores the pushed tag as a lightweight ref, which `git describe` otherwise ignores.
