### PR TITLE
feat(nostrand): skip individual deftests via :exclude-vars

### DIFF
--- a/docs/porting-libraries-to-magic.md
+++ b/docs/porting-libraries-to-magic.md
@@ -50,6 +50,7 @@ When a library needs CLR-specific dependencies (a CLR fork of a JVM library, for
 | `:namespaces` | yes | yes | explicit namespaces, overrides derivation | derived from paths |
 | `:exclude`    | yes | yes | namespaces to drop from the set | none |
 | `:re`         |     | yes | regex string scoping the run (`re-matches`) | the project's own namespaces |
+| `:exclude-vars` |   | yes | fully-qualified `deftest` symbols to skip | none |
 | `:flags`      | yes | yes | flag overrides (see below) | build: production, test: test-friendly |
 | `:out`        | yes |     | compile output dir | `"build"` |
 | `:clean?`     | yes |     | wipe `:out` first | `true` |
@@ -58,6 +59,7 @@ Defaults when a key is omitted:
 
 - `:namespaces`: derived from the paths the aliases contribute (base `:paths` for build; plus the test alias's `:extra-paths` for test).
 - `:re`: the test run is scoped to the project's own namespaces (its suites run, its dependencies' bundled suites do not). Write it as a string, e.g. `"my\\.lib\\..*"`; EDN has no regex literal.
+- `:exclude-vars`: a vector of fully-qualified `deftest` symbols the run clears the `:test` meta on after `require`, so `clojure.test` skips exactly those vars while the rest of their namespace still runs. Use it for a few platform-specific failures scattered inside otherwise-passing namespaces (a Windows-only newline expectation, a Mono-only numeric edge case), where excluding the whole namespace would drop good tests too.
 
 ### Flags
 
@@ -83,6 +85,13 @@ State the compile roots and output directory explicitly (a Unity plugins build, 
 ```clojure
 {:build {:namespaces [my.lib.core my.lib.api]
          :out        "Assets/Plugins/Magic"}}
+```
+
+Skip individual tests that fail only for platform reasons (a Windows CRLF expectation, a Mono numeric edge case), keeping the rest of their namespaces:
+
+```clojure
+{:test {:exclude-vars [my.lib-test/windows-newline-test
+                       my.lib.suite-test/huge-exponent-test]}}
 ```
 
 ### The old way: dotnet.clj

--- a/nostrand/nostrand/tasks.clj
+++ b/nostrand/nostrand/tasks.clj
@@ -240,6 +240,12 @@
                  (`run-all-tests` uses `re-matches`), e.g. #\"flybot\\..*\".
                  Without it the run is scoped to the derived namespaces, so a
                  project's own suites run and its dependencies' do not.
+    :exclude-vars fully-qualified `deftest` symbols to skip. Each var's :test
+                 meta is cleared after `require`, so `clojure.test` runs the
+                 rest of its namespace but omits these, e.g.
+                 [my.ns-test/windows-only-test]. For a handful of
+                 platform-specific failures inside otherwise-passing namespaces,
+                 where a namespace-level `:exclude` would drop good tests too.
     :aliases     deps.edn aliases to activate, e.g. [:clr :test] (so the test
                  source paths land on the load path before `require`)
     :flags       var->value binding map (default `production-flags`)
@@ -248,13 +254,17 @@
   Returns the clojure.test summary map.
   Drop-in for a consumer's `nos dotnet/run-tests`:
       (defn run-tests [] (tasks/run-clojure-tests :aliases [:clr :test]))"
-  [& {:keys [namespaces exclude re aliases flags exit?]
+  [& {:keys [namespaces exclude re aliases flags exit? exclude-vars]
       :or   {flags production-flags exit? true}}]
   (let [basis (when (seq aliases) (nos/establish-deps-edn (basis/project-deps-file) aliases))
         nses  (task-namespaces namespaces aliases exclude basis)]
     (with-bindings flags
       (doseq [ns nses]
         (require ns))
+      (doseq [v exclude-vars]
+        (if-let [var* (resolve v)]
+          (alter-meta! var* assoc :test nil)
+          (println "WARNING: :exclude-vars could not resolve" v)))
       (let [{:keys [fail error] :as summary} (cond
                                                re         (ct/run-all-tests re)
                                                (seq nses) (apply ct/run-tests nses)
@@ -270,9 +280,10 @@
 (s/def ::out        string?)
 (s/def ::clean?     boolean?)
 (s/def ::flags      (s/map-of qualified-symbol? any?))
+(s/def ::exclude-vars (s/coll-of qualified-symbol? :kind vector?))
 
 (s/def ::build (s/keys :opt-un [::aliases ::namespaces ::exclude ::out ::clean? ::flags]))
-(s/def ::test  (s/keys :opt-un [::aliases ::namespaces ::exclude ::re ::flags]))
+(s/def ::test  (s/keys :opt-un [::aliases ::namespaces ::exclude ::re ::flags ::exclude-vars]))
 (s/def ::magic-edn (s/keys :opt-un [::build ::test]))
 
 (defn- read-magic-edn
@@ -313,11 +324,12 @@
   "Run the project's clojure.test suites under MAGIC, per magic.edn :test.
   Run as `nos test`."
   []
-  (let [{:keys [aliases namespaces exclude re flags]
+  (let [{:keys [aliases namespaces exclude re flags exclude-vars]
          :or   {aliases [:test]}}
         (:test (read-magic-edn))]
-    (run-clojure-tests :aliases    (vec aliases)
-                       :namespaces namespaces
-                       :exclude    exclude
-                       :re         (some-> re re-pattern)
-                       :flags      (resolve-flags test-flags flags))))
+    (run-clojure-tests :aliases      (vec aliases)
+                       :namespaces   namespaces
+                       :exclude      exclude
+                       :re           (some-> re re-pattern)
+                       :exclude-vars exclude-vars
+                       :flags        (resolve-flags test-flags flags))))


### PR DESCRIPTION
Closes #96
---

- Add `:exclude-vars` to the `:test` config: a vector of fully-qualified `deftest` symbols whose `:test` meta is cleared after `require`, so `clojure.test` skips exactly those vars and still runs the rest of their namespace.
- Thread it through `run-clojure-tests`, the `test` task, and the `::test` spec (a `qualified-symbol?` vector). An unresolvable symbol warns without aborting the run.
- Document the option in `docs/porting-libraries-to-magic.md`.
