### PR TITLE
fix(nostrand): prefer a dependency's deps-clr.edn over its deps.edn

### DIFF
--- a/docs/clr-dependency-files.md
+++ b/docs/clr-dependency-files.md
@@ -49,7 +49,9 @@ The main cost of `deps-clr.edn` is drift: a git dep used by both runtimes has it
 
 ## How `nos` chooses
 
-`deps-clr.edn` if present at the project root, else `deps.edn`. Project-root only: transitive git and local deps still read their own `deps.edn`. The `nos`-specific keys `:nos/aliases` and `:nos/submodule-paths` are read from whichever file `nos` uses, so move them into `deps-clr.edn` if you add one.
+`deps-clr.edn` if present, else `deps.edn`, both at the project root and for every git or local dep it resolves, the same preference `cljr` applies. A dependency contributes the `:paths` and `:deps` of whichever file it ships, so a library can declare a CLR-only path in its `deps-clr.edn`, the directory of a precompiled assembly for instance, and consumers get it without that path reaching its JVM `deps.edn`.
+
+The `nos`-specific keys `:nos/aliases` and `:nos/submodule-paths` are read from whichever file `nos` uses, so move them into `deps-clr.edn` if you add one.
 
 ## See also
 

--- a/nostrand/nostrand/deps/basis.clj
+++ b/nostrand/nostrand/deps/basis.clj
@@ -47,13 +47,17 @@
 (defn- lib-paths
   "Absolute source paths a resolved lib contributes, rooted at its checkout
   dir. Preference: an explicit :paths on the coord (for git/local deps whose
-  repo has no deps.edn or a non-src layout, e.g. a pom-only contrib lib under
-  src/main/clojure), else the lib's own deps.edn :paths, else [\"src\"]."
+  repo has no deps file or a non-src layout, e.g. a pom-only contrib lib under
+  src/main/clojure), else the lib's own deps file :paths, else [\"src\"]."
   [dir coord lib-deps-edn]
   (map #(str dir "/" %) (or (:paths coord) (:paths lib-deps-edn) default-paths)))
 
-(defn- read-deps-edn [dir]
-  (let [f (str dir "/deps.edn")]
+(defn- read-deps-edn
+  "A dependency's own deps map: deps-clr.edn if present, else deps.edn.
+  Same preference cljr applies to a dep's paths and deps."
+  [dir]
+  (let [clr (str dir "/deps-clr.edn")
+        f   (if (File/Exists clr) clr (str dir "/deps.edn"))]
     (when (File/Exists f)
       (edn/read-string (slurp f)))))
 
@@ -122,8 +126,7 @@
 
 (defn project-deps-file
   "deps-clr.edn if present, else deps.edn. Matches cljr, which reads
-  deps-clr.edn in place of deps.edn. Project root only; transitive deps keep
-  their own deps.edn."
+  deps-clr.edn in place of deps.edn."
   []
   (if (File/Exists "deps-clr.edn") "deps-clr.edn" "deps.edn"))
 


### PR DESCRIPTION
Closes #107
---

- `read-deps-edn` reads a dependency's `deps-clr.edn` in preference to its `deps.edn`, as `cljr` does for both coord-paths and manifest-type. A library declaring its CLR-only `:paths` there, the directory of a precompiled assembly for instance, now pass them to a consumer's `CLOJURE_LOAD_PATH` instead of falling back to the default `["src"]`.
- The preference covers the dependency's `:deps` too, so transitive resolution follows the CLR coordinates of that subtree, matching `cljr`.