### PR TITLE
fix(nostrand): read a coord the way cljr canonicalizes it

### DIFF
--- a/nostrand/nostrand/deps/basis.clj
+++ b/nostrand/nostrand/deps/basis.clj
@@ -1,5 +1,5 @@
 (ns nostrand.deps.basis
-  (:import [System.IO File])
+  (:import [System.IO File Path])
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [nostrand.deps.git :as git]))
@@ -29,6 +29,55 @@
   [{:keys [git/url local/root]}]
   (boolean (or url root)))
 
+(defn- git-coord? [{:keys [git/sha git/tag]}] (boolean (or sha tag)))
+
+(def ^:private git-services
+  "Group-to-url patterns cljr infers from, in clojure.tools.deps.extensions.git."
+  [[#"^(?:com|io)\.github\.([^.]+)$"       "https://github.com/%s/%s.git"]
+   [#"^(?:com|io)\.gitlab\.([^.]+)$"       "https://gitlab.com/%s/%s.git"]
+   [#"^(?:org|io)\.bitbucket\.([^.]+)$"    "https://bitbucket.org/%s/%s.git"]
+   [#"^(?:com|io)\.beanstalkapp\.([^.]+)$" "https://%s.git.beanstalkapp.com/%s.git"]
+   [#"^ht\.sr\.([^.]+)$"                   "https://git.sr.ht/~%s/%s"]])
+
+(defn- auto-git-url
+  [lib]
+  (when-let [group (namespace lib)]
+    (some (fn [[pattern url]]
+            (when-let [[_ owner] (re-matches pattern group)]
+              (format url owner (name lib))))
+          git-services)))
+
+(defn- resolve-root
+  "Absolute path for a coord root: as given when already rooted, else resolved
+  against base."
+  [base root]
+  (if (Path/IsPathRooted root)
+    root
+    (Path/GetFullPath (Path/Combine base root))))
+
+(defn- canonicalize
+  "Coord as tools.deps reads it: the legacy :sha and :tag spellings folded into
+  :git/sha and :git/tag, the :git/url a hosted-service lib name implies, and
+  :local/root resolved against the directory of the deps file declaring it."
+  [lib base {unsha :sha untag :tag :as coord}]
+  (when (and unsha (:git/sha coord))
+    (throw (ex-info "git coord has both :sha and :git/sha" {:lib lib :coord coord})))
+  (when (and untag (:git/tag coord))
+    (throw (ex-info "git coord has both :tag and :git/tag" {:lib lib :coord coord})))
+  (let [coord (cond-> (dissoc coord :sha :tag)
+                unsha (assoc :git/sha unsha)
+                untag (assoc :git/tag untag)
+                (:local/root coord) (update :local/root #(resolve-root base %)))]
+    (if (git-coord? coord)
+      (if-let [url (or (:git/url coord) (auto-git-url lib))]
+        (assoc coord :git/url url)
+        (throw (ex-info (str "Failed to infer git url for: " lib)
+                        {:lib lib :coord coord})))
+      coord)))
+
+(def ^:private unsupported-alias-keys
+  [:deps :paths :replace-deps :replace-paths :default-deps :classpath-overrides])
+
 (defn- merge-aliases
   "Fold the selected aliases into {:paths :deps :overrides}. :extra-paths
   append to :paths; :extra-deps merge onto the dep set; :override-deps are
@@ -40,6 +89,8 @@
     (printerrln "WARNING: Specified aliases are undeclared and are not being used:"
                 (vec undeclared)))
   (let [selected (keep #(get aliases %) alias-kws)]
+    (when-let [unsupported (seq (distinct (mapcat #(filter % unsupported-alias-keys) selected)))]
+      (printerrln "WARNING: alias key(s) cljr honours and nos ignores:" (vec unsupported)))
     {:paths     (into (vec (or paths default-paths)) (mapcat :extra-paths selected))
      :deps      (apply merge deps (map :extra-deps selected))
      :overrides (apply merge (map :override-deps selected))}))
@@ -75,17 +126,18 @@
   "Breadth-first transitive resolution of a deps map. Closest-wins: the
   first sighting of a lib (nearest the root) is kept; later sightings are
   ignored, warning only on a genuine commit divergence (a short sha and the
-  full sha it abbreviates are treated as equal). An entry in overrides
-  replaces a lib's coord wherever it is encountered (a JVM->CLR fork swap),
-  without seeding a root dependency for libs absent from the tree. Returns
+  full sha it abbreviates are treated as equal). A coord's :exclusions prune
+  those libs from its subtree, and an entry in overrides replaces a lib's coord
+  wherever it is encountered (a JVM->CLR fork swap), without seeding a root
+  dependency for libs absent from the tree. Returns
   lib -> {:coord :resolved-sha :paths}."
   [cache deps overrides]
-  (loop [queue   (vec deps)
+  (loop [queue   (vec (for [[lib coord] deps] [lib coord "." #{}]))
          out     {}
          skipped []]
-    (if-let [[lib coord0] (first queue)]
+    (if-let [[lib coord0 base excluded] (first queue)]
       (let [more  (subvec queue 1)
-            coord (get overrides lib coord0)]
+            coord (canonicalize lib base (get overrides lib coord0))]
         (cond
           (runtime-provided? lib)
           (recur more out skipped)
@@ -103,8 +155,14 @@
 
           :else
           (let [{:keys [dir sha]} (procure cache coord)
-                child             (read-deps-edn dir)]
-            (recur (into more (vec (:deps child)))
+                dir               (cond-> dir
+                                    (and (:git/url coord) (:deps/root coord))
+                                    (resolve-root (:deps/root coord)))
+                child             (read-deps-edn dir)
+                excluded          (into excluded (:exclusions coord))]
+            (recur (into more (for [[l c] (:deps child)
+                                    :when (not (contains? excluded l))]
+                                [l c dir excluded]))
                    (assoc out lib {:coord        coord
                                    :resolved-sha (or sha (:git/sha coord) (:git/tag coord))
                                    :paths        (lib-paths dir coord child)})


### PR DESCRIPTION
Closes #109
---

- Coords go through a `canonicalize` step mirroring `clojure.tools.deps.extensions.git`: `:git/url` inferred from a hosted-service lib name (`io.github.user/repo` and the gitlab, bitbucket, beanstalk and sourcehut equivalents) for coords already pinned by sha or tag, and the legacy `:sha` and `:tag` spellings folded into `:git/sha` and `:git/tag`. Carrying both spellings of either throws, as in `cljr`, and so does a git url that can be neither read nor inferred.
- `:deps/root` locates a git dependency's deps file and paths in that subdirectory of the checkout, a relative `:local/root` resolves against the directory of the deps file that declared it, and a coord's `:exclusions` prune the named libs from its subtree.
- The alias keys `cljr` honours and `nos` ignores warn on stderr: `:deps`, `:paths`, `:replace-deps`, `:replace-paths`, `:default-deps` and `:classpath-overrides`.
- Coords `nos` skipped before are now cloned, so one that is unreachable or wrongly pinned fails at resolution instead of silently.
