### PR TITLE
fix(tooling): exit non-zero when refresh-stdlib or the test suite fails (#122)

### DIFF
--- a/magic-compiler/refresh.clj
+++ b/magic-compiler/refresh.clj
@@ -72,6 +72,29 @@
         p   (Path/Combine stdlib-root (str rel ".clj"))]
     (when (File/Exists p) (FileInfo. p))))
 
+(defn- compile-namespaces!
+  "Compile each namespace into tmp-dir, printing progress. Returns a vector of
+   [ns message] for the ones that threw, empty when all of them compiled."
+  [namespaces tmp-dir]
+  (binding [clojure.core/*eval-form-fn*       api/eval
+            clojure.core/*compile-file-fn*    api/runtime-compile-file
+            clojure.core/*load-file-fn*       api/runtime-load-file
+            clojure.core/*warn-on-reflection* true
+            clojure.core/*compile-path*       tmp-dir
+            clojure.core/*compile-files*      true]
+    (reduce (fn [failed ns]
+              (print (str "compiling " ns " ... "))
+              (flush)
+              (try
+                (api/compile-namespace ns {:write-files true :suppress-print-forms true})
+                (println "ok")
+                failed
+                (catch Exception e
+                  (println "FAILED:" (.Message e))
+                  (conj failed [ns (.Message e)]))))
+            []
+            namespaces)))
+
 (defn stdlib [& _args]
   ;; ordinal sort: compile order feeds the gensym stream, and the default
   ;; culture-sensitive string compare orders differently across OS collations
@@ -109,20 +132,16 @@
     (when (Directory/Exists tmp-dir) (Directory/Delete tmp-dir true))
     (Directory/CreateDirectory tmp-dir)
 
-    (binding [clojure.core/*eval-form-fn*       api/eval
-              clojure.core/*compile-file-fn*    api/runtime-compile-file
-              clojure.core/*load-file-fn*       api/runtime-load-file
-              clojure.core/*warn-on-reflection* true
-              clojure.core/*compile-path*       tmp-dir
-              clojure.core/*compile-files*      true]
-      (doseq [ns (concat top-level-nss subfile-nss)]
-        (print (str "compiling " ns " ... "))
-        (flush)
-        (try
-          (api/compile-namespace ns {:write-files true :suppress-print-forms true})
-          (println "ok")
-          (catch Exception e
-            (println "FAILED:" (.Message e))))))
+    (let [to-compile (concat top-level-nss subfile-nss)]
+      ;; a half-refreshed set of committed DLLs is what this task exists to prevent
+      (when-let [failures (seq (compile-namespaces! to-compile tmp-dir))]
+        (println (str (count failures) " of " (count to-compile)
+                      " namespaces failed to compile, so nothing was deployed"
+                      " and the committed DLLs are untouched:"))
+        (doseq [[ns message] failures]
+          (println (str "  " ns " - " message)))
+        (throw (ex-info "refresh/stdlib did not compile every namespace"
+                        {:failed (mapv first failures)}))))
 
     (let [produced (->> (Directory/EnumerateFiles tmp-dir "clojure.*.clj.dll")
                         (map #(Path/GetFileName ^String %))

--- a/magic-compiler/test.clj
+++ b/magic-compiler/test.clj
@@ -24,30 +24,40 @@
    magic.test.load)
   (:use clojure.test))
 
+(defn- check-summary!
+  "Throw when the run had failures or errors. clojure.test/run-tests only
+   reports them in its return value, and nostrand ignores what a task returns,
+   so throwing is the only way a red suite reaches the process exit code."
+  [{:keys [fail error] :as summary}]
+  (when (pos? (+ fail error))
+    (throw (ex-info "test suite failed" (dissoc summary :type))))
+  summary)
+
 (defn all []
-  (run-tests
-   'magic.test.literals
-   'magic.test.data-structures
-   'magic.test.string
-   'magic.test.logic
-   'magic.test.control
-   'magic.test.numbers
-   'magic.test.interop
-   'magic.test.special
-   'magic.test.dynamic
-   'magic.test.proxy
-   'magic.test.reify
-   'magic.test.fn
-   'magic.test.letfn
-   'magic.test.pipeline
-   'magic.test.hash
-   'magic.test.stdlib
-   'magic.test.spec
-   'magic.test.deterministic
-   'magic.test.flags
-   'magic.test.protocol
-   'magic.test.errors
-   'magic.test.load))
+  (check-summary!
+   (run-tests
+    'magic.test.literals
+    'magic.test.data-structures
+    'magic.test.string
+    'magic.test.logic
+    'magic.test.control
+    'magic.test.numbers
+    'magic.test.interop
+    'magic.test.special
+    'magic.test.dynamic
+    'magic.test.proxy
+    'magic.test.reify
+    'magic.test.fn
+    'magic.test.letfn
+    'magic.test.pipeline
+    'magic.test.hash
+    'magic.test.stdlib
+    'magic.test.spec
+    'magic.test.deterministic
+    'magic.test.flags
+    'magic.test.protocol
+    'magic.test.errors
+    'magic.test.load)))
 
 (defn run [& namespaces]
-  (apply run-tests namespaces))
+  (check-summary! (apply run-tests namespaces)))


### PR DESCRIPTION
Closes #122
---

- `refresh-stdlib` collects compile failures and throws before the copy step, so the committed DLLs stay untouched.
- `test/all` and `test/run` throw when the summary reports failures, so a red suite now fails `bb test`. 
