### PR TITLE
docs(repo): rewrite the guides and READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,4 +90,4 @@ When a change affects the committed `.clj.dll`s under `nostrand/references/` and
 
     chore(bootstrap): refresh <name> DLL for <short reason> (#<issue>)
 
-Compilation is deterministic: rebuilding unchanged sources reproduces the committed bytes exactly, so only genuinely affected DLLs show up in `git status`, and `bb check-drift` fails if a stale one is left uncommitted.
+Compilation is deterministic: rebuilding unchanged sources reproduces the committed bytes exactly, so only genuinely affected DLLs show up in `git status`, and `bb check-drift` fails if a stale one is left uncommitted. If binaries you did not expect appear after a rebuild, that is a real change worth understanding before reverting anything.

--- a/Magic.csproj
+++ b/Magic.csproj
@@ -1,7 +1,6 @@
-<Project>
+<Project DefaultTargets="All">
     <PropertyGroup>
         <NostrandExeNet4x>nostrand/bin/Release/net471/NostrandMain.exe</NostrandExeNet4x>
-        <NostrandExeNet5>nostrand/bin/Release/net5.0/NostrandMain.dll</NostrandExeNet5>
         <MagicUnityInfrastructureExport>magic-unity/Runtime/Infrastructure/Export</MagicUnityInfrastructureExport>
         <ClojureRuntimeDllNet471>clojure-runtime/bin/Release/net471/Clojure.dll</ClojureRuntimeDllNet471>
         <ClojureRuntimeDllNetStandard>clojure-runtime/bin/Release/netstandard2.0/Clojure.dll</ClojureRuntimeDllNetStandard>
@@ -21,7 +20,9 @@
         <Exec Command="dotnet build -t:MagicUnity" />
     </Target>
 
-    <Target Name="Nostrand" Condition="!Exists('$(NostrandExeNet4x)') Or !Exists('$(NostrandExeNet5)')">
+    <!-- Do not guard on Exists(): dotnet build is incremental by timestamp, and an
+         existence check keeps a stale host after a C# edit. -->
+    <Target Name="Nostrand">
         <Exec WorkingDirectory="nostrand" Command="dotnet build -c Release" />
     </Target>
     <Target Name="Magic" DependsOnTargets="Nostrand" Condition="!Exists('$(MagicBootstrap)')">
@@ -38,6 +39,6 @@
     </Target>
 
     <Target Name="Clean">
-        <RemoveDir Directories="clojure-runtime/bin;nostrand/bin;magic-runtime/bin;magic-compiler/bootstrap" />
+        <RemoveDir Directories="clojure-runtime/bin;nostrand/bin;magic-runtime/Magic.Runtime/bin;magic-runtime/Magic.Runtime.Callsites/bin;magic-compiler/bootstrap" />
     </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # MAGIC
 
 [![Build](https://img.shields.io/github/actions/workflow/status/flybot-sg/magic/ci.yml?label=build&branch=main)](https://github.com/flybot-sg/magic/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/flybot-sg/magic/ci.yml?label=tests&branch=main)](https://github.com/flybot-sg/magic/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/flybot-sg/magic)](https://github.com/flybot-sg/magic/releases/latest)
 [![Clojure](https://img.shields.io/badge/clojure-1.10-blue.svg?logo=clojure&logoColor=white)](https://clojure.org/)
 [![.NET](https://img.shields.io/badge/.NET-Framework%204.7.1%20%2F%20netstandard%202.0-512BD4.svg?logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
@@ -15,9 +14,9 @@ A Clojure compiler targeting the Common Language Runtime (.NET). MAGIC compiles 
 
 Flybot uses MAGIC in production to ship Clojure game logic on Unity, including iOS via IL2CPP. The compiler is feature-complete against the Clojure 1.10 language and standard library, and still maturing (not yet as battle-tested as JVM Clojure). Concretely:
 
-- **Clojure 1.10 stdlib parity.** The marked-1.10 surface runs on the CLR (`ex-message`, `tap>`, `read+string`, `Throwable->map`, the `prepl` family, ...). MAGIC targets 1.10; the later releases (1.11 and the current 1.12) are not ported ([details](./docs/writing-cross-platform-clojure.md)).
+- **Clojure 1.10 stdlib parity.** The marked-1.10 surface runs on the CLR (`ex-message`, `tap>`, `read+string`, `Throwable->map`, the `prepl` family, ...). MAGIC targets 1.10; 1.11 and 1.12 are not ported ([details](./docs/writing-cross-platform-clojure.md)).
 - **Runs in Unity, including IL2CPP and iOS.** MAGIC emits fully static MSIL, so it survives AOT compilation where the DLR-based ClojureCLR cannot ([why and how](./docs/why-magic.md)). Ships as a UPM package in two variants (see [Install](#install)).
-- **Same source on JVM and CLR.** A clean `.cljc` library within the 1.10 stdlib compiles unchanged on both MAGIC and ClojureCLR, with no MAGIC-specific patches.
+- **Same source on JVM and CLR.** A clean `.cljc` library within the 1.10 stdlib compiles unchanged on both MAGIC and ClojureCLR. `nos` reads `deps-clr.edn` and `.cljr` sources the way `cljr` does, so a library ported the ClojureCLR way needs no MAGIC-specific setup ([details](./docs/clr-dependency-files.md)).
 - **IL2CPP-tested.** A standalone Unity smoke project exercises AOT-only regressions on the verified Unity version; green on Mono and Standalone IL2CPP ([smoke suite](./unity-examples/magic-unity-smoke)).
 
 ## About this version
@@ -28,20 +27,24 @@ This monorepo bundles the six MAGIC repositories ([magic](https://github.com/nas
 
 This is not a replacement of Ramsey's MAGIC. It's the version Flybot maintains.
 
-## Rationale
-
-The JVM Clojure compiler targets the Java Virtual Machine. MAGIC targets .NET instead, taking full advantage of the CLR's features to produce better bytecode. This enables Clojure in environments where the JVM cannot run, notably Unity game engine (including iOS via IL2CPP).
-
-MAGIC is a self-hosting compiler: it is written in Clojure and compiles itself through Nostrand, its task runner.
-
 ## Documentation
 
 - [Why MAGIC](./docs/why-magic.md): why a static CLR compiler is needed (iOS forbids the runtime code generation ClojureCLR's DLR relies on; IL2CPP only AOT-compiles IL that already exists).
+- [MAGIC architecture](./docs/architecture.md): the components, what each one does, and how they fit together.
+
+Using MAGIC on your own library:
+
+- [Porting a Clojure library to MAGIC](./docs/porting-libraries-to-magic.md): the four steps, then testing and CI.
 - [Writing cross-platform Clojure](./docs/writing-cross-platform-clojure.md): `.cljc` source patterns for code that runs on both the JVM and the CLR.
-- [Porting a Clojure library to MAGIC](./docs/porting-libraries-to-magic.md): `deps.edn`, `magic.edn`, and CI for a CLR build.
 - [Declaring CLR dependencies](./docs/clr-dependency-files.md): `deps-clr.edn` vs a `:clr` alias, when the CLR needs different deps than the JVM.
+- [The `nos` CLI](./docs/nos-cli.md): how a task is found, `nos build` and `nos test`, and the `magic.edn` surface.
 - [Loading precompiled native assemblies](./docs/native-assemblies.md): loading a committed C# DLL on the CLR, where `:import` alone does not.
 - [Unity integration](./docs/unity-integration.md): compile `.clj.dll` and load them in a Unity project.
+
+Working on MAGIC itself:
+
+- [Development](./docs/development.md): every `bb` task in depth, which rebuild your edit needs, and the tools for inspecting a form.
+- [The bootstrap](./docs/bootstrap.md): what is committed and why, which task owns which DLL, and how many passes a change needs.
 - [Deterministic compilation and the drift check](./docs/deterministic-compilation.md): why the committed DLLs are byte-diffed against a rebuild, and the contributor workflows that follow.
 
 Per-component reference lives in each component's own README, linked from [Components](#components) below. To contribute, see [CONTRIBUTING.md](./CONTRIBUTING.md).
@@ -50,38 +53,19 @@ Per-component reference lives in each component's own README, linked from [Compo
 
 | Component | Description | Language |
 |-----------|-------------|----------|
-| [clojure-runtime](./clojure-runtime) | Persistent data structures, Keywords, Vars, reader | C# |
-| [magic-runtime](./magic-runtime) | Fast dynamic call sites | C# |
-| [mage](./mage) | Symbolic MSIL bytecode emitter | Clojure |
-| [magic-compiler](./magic-compiler) | The compiler (s-expressions to MSIL) | Clojure |
-| [nostrand](./nostrand) | Task runner, dependency manager, REPL | C# + Clojure |
-| [magic-unity](./magic-unity) | Unity integration package (IL2CPP support), default variant | C# |
-| [magic-unity-dual](./magic-unity-dual) | Coexistence variant of magic-unity with the runtime excluded from the Editor (for projects that keep stock ClojureCLR). Generated by `bb gen-unity-dual`; see [Unity integration](./docs/unity-integration.md). | C# |
-| [magic-unity-smoke](./unity-examples/magic-unity-smoke) | Standalone Unity project that exercises MAGIC under IL2CPP. Regression suite for AOT-only bugs, runs by hand on the verified Unity version (`2022.3.62f3`). | Clojure + C# |
+| [clojure-runtime](./clojure-runtime) | Clojure's data model in C#: persistent collections, keywords, vars, the reader. Every compiled DLL runs on it. | C# |
+| [magic-runtime](./magic-runtime) | Resolves the interop calls whose types are only known at run time, caching each call site. Emits no IL at run time, which is what IL2CPP requires. | C# |
+| [mage](./mage) | MSIL as Clojure data, so bytecode can be built and rewritten as plain values before it is emitted. | Clojure |
+| [magic-compiler](./magic-compiler) | The compiler: Clojure forms to MSIL. Also holds the standard library sources it compiles. | Clojure |
+| [nostrand](./nostrand) | The `nos` CLI: hosts the compiler, resolves dependencies, runs the build, test and REPL tasks. | C# + Clojure |
+| [magic-unity](./magic-unity) | The UPM package Unity loads at play time: the prebuilt runtime plus the IL2CPP pre-build step. Default variant, MAGIC runs in the Editor too. | C# |
+| [magic-unity-dual](./magic-unity-dual) | The same package with the runtime hidden from the Editor, for projects that keep ClojureCLR there. Generated by `bb gen-unity-dual`; see [Unity integration](./docs/unity-integration.md). | C# |
+| [magic-unity-smoke](./unity-examples/magic-unity-smoke) | Unity project that drives compiled output through IL2CPP, catching the AOT-only bugs Mono cannot reach. Run by hand on Unity `2022.3.62f3`. | Clojure + C# |
+| [magic-unity-coexist](./unity-examples/magic-unity-coexist) | Unity project that vendors ClojureCLR to reproduce the Editor console noise of running both runtimes. Driven by `bb coexist-noise`. | C# |
 
-Each component has its own README with detailed documentation.
+Each component has its own README with detailed documentation, and [MAGIC architecture](./docs/architecture.md) shows how they fit together.
 
 `clojure-runtime/` is forked from [ClojureCLR](https://github.com/clojure/clojure-clr) (a .NET port of Clojure maintained by David Miller). Its full commit history is preserved here, so David Miller and other ClojureCLR contributors appear in the GitHub contributors view.
-
-## Architecture
-
-```
-Runtimes (C#, ship as DLLs)
-  clojure-runtime   Clojure data: PersistentMap, Vars, Keywords (forked ClojureCLR)
-  magic-runtime     dynamic call sites for Clojure-on-CLR
-
-Compiler (Clojure, AOT-compiles .clj -> .clj.dll)
-  mage              symbolic MSIL emitter
-  magic-compiler    Clojure compiler proper (uses mage)
-
-Host (C#)
-  nostrand          CLI task runner; links the runtimes, hosts the compiler
-
-Packaging
-  magic-unity       UPM package: bundles runtime + compiler DLLs for Unity
-```
-
-`bootstrap` is a build phase, not a component: compile `magic-compiler` with the previous `nos`, copy the resulting `.clj.dll`s back into `nostrand/references/`, rebuild `nos` against them. See [Development](#development).
 
 ## Install
 
@@ -89,14 +73,14 @@ Two shippable artifacts; pick the one(s) your project needs.
 
 **`nos` CLI**: a build-time task runner that compiles Clojure to MSIL. Used by Unity projects (before opening Unity) and by non-Unity Clojure libs that want CLR test runs.
 
-- Built from `nostrand/` + `clojure-runtime/` + `magic-runtime/` + `magic-compiler/`.
+- Built from `nostrand/` + `clojure-runtime/` + `magic-runtime/` + `magic-compiler/` + `mage/`.
 - Ships as a GitHub Releases tarball, cut on every `v*` tag by [`release.yml`](.github/workflows/release.yml).
 - Consumers install it with `install/nos.sh` (one-line curl; needs `mono`, no .NET SDK).
 
 **`magic-unity` UPM package**: the play-time Clojure runtime plus the IL2CPP build pre-processor, loaded by Unity inside a project. It ships in **two variants**, and picking one is the first decision:
 
-- **`sg.flybot.magic.unity`** (default): MAGIC runs everywhere, including the Editor's Play mode. Pin `?path=magic-unity#<tag>`. Use this unless your Editor already runs stock ClojureCLR.
-- **`sg.flybot.magic.unity.dual`**: the runtime is excluded from the Editor (`!UNITY_EDITOR`), so the Editor keeps stock ClojureCLR (REPL / hot-reload) and MAGIC ships only in player builds. Pin `?path=magic-unity-dual#<tag>`.
+- **`sg.flybot.magic.unity`** (default): MAGIC runs everywhere, including the Editor's Play mode. Pin `?path=magic-unity#<tag>`. Use this unless your Editor already runs ClojureCLR.
+- **`sg.flybot.magic.unity.dual`**: the runtime is excluded from the Editor (`!UNITY_EDITOR`), so the Editor keeps ClojureCLR (REPL / hot-reload) and MAGIC ships only in player builds. Pin `?path=magic-unity-dual#<tag>`.
 
 Player builds are identical either way. Both are pinned by git tag and added as a UPM git URL in `Packages/manifest.json`; full comparison in [Unity integration](./docs/unity-integration.md).
 
@@ -116,176 +100,56 @@ You need three things: the `nos` CLI (build-time), the `magic-unity` UPM package
 
    Defaults install to `$HOME/.local/nostrand/` with the launcher symlinked to `$HOME/.local/bin/nos`. Override with `INSTALL_DIR=` / `INSTALL_LINK=` env vars if needed.
 
-2. **Add the package, compile, open Unity.** The [Unity integration guide](./docs/unity-integration.md) covers the `Packages/manifest.json` pin (and which of the two variants to pick: default, or `.dual` for projects that keep stock ClojureCLR in the Editor), the `deps.edn` / `magic.edn` setup, `nos build`, and IL2CPP.
+2. **Add the package, compile, open Unity.** The [Unity integration guide](./docs/unity-integration.md) covers the `Packages/manifest.json` pin (and which of the two variants to pick: default, or `.dual` for projects that keep ClojureCLR in the Editor), the `deps.edn` / `magic.edn` setup, `nos build`, and IL2CPP.
 
 ### Use `nos` for non-Unity Clojure-on-CLR
 
-Same `install/nos.sh` line, no Unity needed. Drop a `deps.edn` at your library root (CLR-specific deps go in a `deps-clr.edn` or a `:clr` alias, see [Declaring CLR dependencies](./docs/clr-dependency-files.md)), add an optional `magic.edn`, then `nos build` and `nos test`. Tests execute under Mono via the `nos` you just installed. [Porting a Clojure library to MAGIC](./docs/porting-libraries-to-magic.md) walks through the whole workflow: reader conditionals, `deps.edn` / `deps-clr.edn`, and the `magic.edn` build/test configuration. [Writing cross-platform Clojure](./docs/writing-cross-platform-clojure.md) covers the `.cljc` source patterns themselves: type hints, host interop, records and protocols, and the Clojure 1.10 stdlib surface.
+Same `install/nos.sh` line, no Unity needed. Declare the CLR coordinates in a `deps-clr.edn` (or a `deps.edn` with a `:clr` alias), state what differs from the defaults in an optional `magic.edn`, then `nos build` and `nos test`, which run under the `mono` that hosts `nos`. [Porting a Clojure library to MAGIC](./docs/porting-libraries-to-magic.md) is the ordered walkthrough.
 
-## Prerequisites for working on MAGIC itself
+## Development
 
-Consumer install needs `bash`, `curl`, `tar`, and `mono` runtime. Contributing to MAGIC needs:
+Consuming MAGIC needs `bash`, `curl`, `tar` and `mono`. Working on it needs:
 
 - [`git`](https://git-scm.com/)
-- [`dotnet`](https://dotnet.microsoft.com/en-us/download) (v7+)
-- [`mono`](https://www.mono-project.com/) (only needed at build time to host Nostrand; will go away once we drop net471)
-- [`bb`](https://github.com/babashka/babashka) (optional, for the dev workflows in [Development](#development))
+- [`dotnet`](https://dotnet.microsoft.com/en-us/download) SDK 7 and 8 (what CI installs; the callsite generator targets `net8.0`)
+- [`mono`](https://www.mono-project.com/) (hosts Nostrand at build time)
+- [`bb`](https://github.com/babashka/babashka) (the build tasks stamp the committed DLL timestamps before compiling, so a correct build goes through them)
 
 ```bash
 git clone https://github.com/flybot-sg/magic.git
 cd magic
-bb build         # or: dotnet build
+bb build
 ```
 
-The full build takes a few minutes on first run. Subsequent builds are incremental. Day-to-day workflows are in [Development](#development) below.
+That takes a few minutes, every time: `bb build` cleans first, so the bootstrap is always redone from scratch. Day to day you want the task that matches your edit instead.
 
-## Development
+This repo mixes C# (runtimes + host) and Clojure (compiler + stdlib), and the two rebuild on very different timescales. `bb.edn` encodes which rebuild matches which edit:
 
-This repo mixes C# (runtimes + host) and Clojure (compiler + stdlib). Different edits need different rebuilds; doing the wrong one wastes minutes per iteration. The `bb` task runner encodes which rebuild matches which edit.
+| You changed | Run | What it costs |
+|---|---|---|
+| any C# in `clojure-runtime/`, `magic-runtime/` or `nostrand/` | `bb build-runtime` | a C# build |
+| a callsite `.mustache` template | `bb dev-callsites` | regen, then a C# build |
+| `magic-compiler/src/stdlib/`, outside the `clojure.core` family | `bb refresh-stdlib` | one compile pass over the stdlib |
+| `magic-compiler/src/magic/`, `mage/src/`, or the `clojure.core` family | `bb dev-compiler` | two bootstrap passes |
 
-### What needs what
+[The development guide](./docs/development.md) covers every task in depth: what each one rebuilds, why they all go through `bb`, how the drift check works, and the `bb pipeline` and prepl tools for inspecting a form.
 
-| You changed                          | Run                | Why                                                                                  |
-|--------------------------------------|--------------------|--------------------------------------------------------------------------------------|
-| `clojure-runtime/**/*.cs`            | `bb dev-runtime`   | `.clj.dll` references runtime DLLs by name; new bodies load without re-bootstrap     |
-| `magic-runtime/Magic.Runtime/*.cs`   | `bb dev-runtime`   | Same                                                                                 |
-| `*.mustache` (callsite templates)    | `bb dev-callsites` | Regenerates `.g.cs` first, then rebuilds runtime                                     |
-| `nostrand/*.cs` (host code)          | `bb build-runtime` | Rebuilds nostrand (and runtimes transitively via `ProjectReference`)                 |
-| `magic-compiler/src/**/*.clj`        | `bb dev-compiler`  | Compiler is bootstrapped; cold tests need re-bootstrap                               |
-| `magic-compiler/src/stdlib/**/*.clj` | `bb dev-compiler`  | Same                                                                                 |
-| Fresh checkout                       | `bb build`         | Full bootstrap                                                                       |
+### The committed binaries
 
-For interactive iteration on compiler `.clj` files, prefer `bb repl` plus `(require '... :reload)` over re-running `bb dev-compiler` each time.
+MAGIC is self-hosting, so compiling the compiler needs a working compiler. Two folders of pre-built binaries are tracked in git to break that circle:
 
-### The bootstrap chicken-and-egg
+- `nostrand/references/*.clj.dll`: 73 DLLs, the compiler and stdlib Nostrand loads at startup. They are what compiles the next compiler.
+- `magic-unity/Runtime/Infrastructure/Export/`: the two runtime DLLs plus 37 stdlib `.clj.dll`, what Unity loads at play time
 
-MAGIC is self-hosting: the compiler is Clojure code that emits CLR bytecode, and it needs a previous version of itself to compile. The repo ships pre-built `.clj.dll` files in `nostrand/references/` for this reason. They ARE the compiler that compiles the new compiler.
+That is why a C# edit is cheap and a compiler edit is not. Compiled `.clj.dll` name `Clojure.dll` and `Magic.Runtime.dll` in their assembly references and pick up new bodies at load time, so a C# change never needs a bootstrap. Only the compiler's own source and the `clojure.core` family take the slow path.
 
-Practical consequence: `bb dev-runtime` does not need a bootstrap. Already-compiled `.clj.dll` files reference `Magic.Runtime.dll` and `Clojure.dll` by name and pick up new bodies at load time. Only `bb dev-compiler` (changes to compiler or stdlib `.clj` source) triggers the slow re-bootstrap path.
+Compilation is deterministic: rebuilding unchanged sources reproduces the committed bytes exactly, so `git status` after a rebuild shows only the DLLs a change really affected, and those get committed in a paired refresh commit alongside the source fix. `bb check-drift` byte-diffs the whole set against a rebuild. [The bootstrap](./docs/bootstrap.md) has the ownership rules, and [Deterministic compilation and the drift check](./docs/deterministic-compilation.md) covers what makes the byte diff work.
 
-### Refreshing the bootstrap binaries
+### Testing
 
-Two folders of pre-built binaries are tracked in git:
+`bb test` runs the compiler suite, `magic-compiler/test/magic/test/*.clj`, entered through the `test/all` var in [magic-compiler/test.clj](magic-compiler/test.clj). Pass namespace names to run a subset. Downstream projects run `nos test` instead ([the `nos` CLI](./docs/nos-cli.md)).
 
-- `nostrand/references/*.clj.dll`: the compiler Nostrand loads at startup
-- `magic-unity/Runtime/Infrastructure/Export/*.dll`: the prebuilt runtime that Unity loads at play time
-
-Compilation is deterministic: rebuilding unchanged sources reproduces the committed bytes exactly, so `git status` after a rebuild shows only the DLLs a change really affected, and those get committed together with the source fix. A maintainer refreshes them by running either `bb build` (full path) or `bb bootstrap` (faster: re-bootstrap + deploy). For stdlib-only edits (any `magic-compiler/src/stdlib/**/*.clj`), `bb refresh-stdlib` recompiles only the affected `.clj.dll` files. Both paths refresh `nostrand/references/` and `magic-unity/Runtime/Infrastructure/Export/` together, and `bb check-drift` byte-diffs the compiled `.clj.dll` binaries against a rebuild to catch stale ones. The design and its edge cases are covered in [Deterministic compilation and the drift check](./docs/deterministic-compilation.md).
-
-### Common workflows
-
-```bash
-bb tasks         # list all tasks with their docs
-bb build         # full build (minutes, first time)
-bb build-runtime # incremental C# runtimes + nostrand (seconds)
-bb test          # run magic-compiler test suite
-bb dev-runtime   # build-runtime + test  (after C# runtime edits)
-bb dev-callsites # regen + build-runtime + test  (after .mustache edits)
-bb dev-compiler  # bootstrap + test  (after compiler .clj edits)
-bb check-drift   # regen + rebuild stdlib, fail if generated files or committed DLLs are stale (CI uses this after a fresh build)
-bb repl          # nostrand CLI REPL in magic-compiler/
-bb clean         # remove bin/ and bootstrap/
-```
-
-### Inspecting the compiler pipeline
-
-Walk a form through the stages: form → macroexpand → AST → symbolic IL.
-
-```bash
-bb pipeline '(let [x 1] (+ x 1))'
-```
-
-Prints to stdout:
-
-| Section          | What it shows                                                                                                                             |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `FORM`           | The input                                                                                                                                 |
-| `MACROEXPAND`    | Shown only when expansion differs from input                                                                                              |
-| `AST (skeleton)` | Analyzer output with bookkeeping keys (`:env`, source-position, `:raw-forms`) stripped                                                    |
-| `TYPES`          | Every AST node carrying type info; useful for diagnosing intrinsic rewrites, static vs dynamic call-site selection, and numeric promotion |
-| `SYMBOLIC IL`    | Flat instruction listing in emission order                                                                                                |
-
-Also writes EDN dumps under `magic-compiler/target/`:
-
-| File                   | What it is                                                                                                                                                                        |
-|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pipeline-ast.edn`     | Full AST, pprinted                                                                                                                                                                |
-| `pipeline-il.edn`      | Flat instruction list, pprinted (usually what you want)                                                                                                                           |
-| `pipeline-il-tree.edn` | Nested IL tree as mage emits it. The `nil` placeholders are structural alignment that mage filters at byte-emit time; the flat dump is the same instructions without the nesting. |
-
-Forms that synthesize CLR types (`fn`, `defn`, `deftype`, `defrecord`) work too. No destination assembly is needed.
-
-Options (`:key value` pairs after the form):
-
-| Key         | Default                                 | Effect                                                                                              |
-|-------------|-----------------------------------------|-----------------------------------------------------------------------------------------------------|
-| `:out`      | `target`                                | Output directory for EDN dumps                                                                      |
-| `:sections` | all eight                               | Subset of `#{:form :macroexpand :ast :types :il :ast-edn :il-edn :tree-edn}` controlling what renders |
-
-```bash
-bb pipeline '(let [x 1] x)' :out /tmp/inspect
-bb pipeline '(let [x 1] x)' :sections '#{:ast :il}'           # stdout-only, no files
-bb pipeline '(.Length "hi")' :sections '#{:il-edn}' :out /tmp # just dump the flat IL
-```
-
-### Evaluating against a live runtime (prepl)
-
-`bb pipeline` shows the *compiled IL* for a form but never runs it. To see what
-a form actually returns at runtime, evaluate it against a warm MAGIC runtime
-over a socket prepl (the MAGIC analogue of a Clojure nREPL). Complementary to
-`bb pipeline`: pipeline answers "how does this compile", prepl answers "what
-does this do".
-
-Start the server in one shell (it blocks, serving connections):
-
-```bash
-bb prepl-server            # listens on 127.0.0.1:5555 (override: bb prepl-server 5560)
-```
-
-Send forms from another shell. Each prints the structured reply map:
-
-```bash
-bb prepl-eval '(+ 1 2)'
-#=> {:tag :ret, :val "3", :ns "user", :ms 1.3, :form "(+ 1 2)"}
-
-bb prepl-eval '(def answer 42)'   # global defs persist across calls
-bb prepl-eval '(* answer 2)'      #=> {:tag :ret, :val "84", ...}
-
-bb prepl-eval '(/ 1 0)'           # errors come back as data, not a text dump
-#=> {:tag :ret, :exception true, :val "{... :cause \"Divide by zero\" :phase :execution}", ...}
-```
-
-Reply tags: `:ret` (eval result + `:ms` timing), `:out`/`:err` (captured
-stdout/stderr during eval), `:tap` (values from `tap>`); an `:exception true`
-`:ret` carries the `Throwable->map` data. The server is MAGIC Clojure
-(`clojure.core.server/io-prepl`); the `bb prepl-eval` client is plain babashka,
-so each call is fast. This runs only under Mono/nostrand: prepl evaluates at
-runtime, so it has no IL2CPP/AOT path.
-
-### MSBuild targets (underlying)
-
-The actual build is orchestrated by `Magic.csproj`. The `bb` tasks call into these; invoke them directly if you'd rather not install bb.
-
-| Target                       | Description                                              |
-|------------------------------|----------------------------------------------------------|
-| `dotnet build`               | Full build (all components in dependency order)          |
-| `dotnet build -t:Nostrand`   | Build task runner only                                   |
-| `dotnet build -t:Magic`      | Magic compiler bootstrap (requires mono)                 |
-| `dotnet build -t:Bootstrap`  | Copy compiler DLLs into Nostrand, rebuild                |
-| `dotnet build -t:MagicUnity` | Unity package                                            |
-| `dotnet build -t:Clean`      | Remove build artifacts                                   |
-
-## Testing
-
-```bash
-bb test
-# or directly:
-cd magic-compiler && mono ../nostrand/bin/Release/net471/NostrandMain.exe test/all
-```
-
-The MAGIC compiler itself uses the `test/all` entrypoint in [magic-compiler/test.clj](magic-compiler/test.clj). Downstream projects run `nos test` (see the Getting Started section above for the pattern).
-
-For IL2CPP-specific regressions (AOT-only bugs that the Mono editor cannot catch), [magic-unity-smoke](./unity-examples/magic-unity-smoke) drives MAGIC's compile output through Unity's IL2CPP pipeline and reports pass/fail in the built player. Run by hand on the verified Unity version after touching the compiler, the runtimes, or `magic-unity` itself.
+The suite runs with the production flags off, bar a few direct-linking cases in `magic.test.fn`, so it tells you little about how a compiler change behaves under `*direct-linking*` and `*strongly-typed-invokes*` ([what they change](./docs/nos-cli.md#compiler-flags)); build a real consumer project as well. AOT-only bugs need a real Unity build: [magic-unity-smoke](./unity-examples/magic-unity-smoke) drives MAGIC's output through IL2CPP and reports pass/fail in the built player. Run it by hand on the verified Unity version after touching the compiler, the runtimes, or `magic-unity`.
 
 ## Contributing
 

--- a/bb.edn
+++ b/bb.edn
@@ -15,36 +15,34 @@
   ;; ============================================================
 
   build
-  {:doc "Full build: runtimes → nostrand → magic-compiler bootstrap → magic-unity. Slow (minutes) on first run.
-         Normalizes committed-DLL mtimes first, so use this rather than raw `dotnet build` after a fresh clone (byte reproducibility depends on it)."
+  {:doc "Full build: clean → runtimes → nostrand → magic-compiler bootstrap → magic-unity.
+         Slow every time.
+         Stamps committed-DLL mtimes before compiling, which a raw `dotnet build` skips.
+         See docs/development.md."
    :requires ([magic.drift :as drift])
    :task (do (drift/touch-dlls!)
              (shell "dotnet build"))}
 
   build-runtime
-  {:doc "Rebuild C# runtimes (clojure-runtime + magic-runtime) and nostrand. No magic-compiler bootstrap. Fast."
+  {:doc "Rebuild C# runtimes (clojure-runtime + magic-runtime) and nostrand.
+         No magic-compiler bootstrap.
+         Fast."
    :task (shell "dotnet build" "nostrand/NostrandMain.csproj" "-c" "Release")}
 
   bootstrap
-  {:doc "Re-bootstrap magic-compiler (.clj → .clj.dll), deploy the DLLs into nostrand/references (rebuilds nostrand) and magic-unity Export, then re-record dll-sources.edn. Slow.
+  {:doc "One bootstrap pass: compile magic-compiler with the compiler in references/, deploy over it (rebuilds nostrand) and into magic-unity Export, re-record dll-sources.edn.
+         Slow.
          Extra args go to nos build/bootstrap, e.g. `bb bootstrap :spells '[magic.spells.sparse-case/sparse-case]'`.
-         Self-hosting: after compiler changes run twice; the second pass is the fixpoint."
-   :requires ([babashka.fs :as fs]
-              [magic.drift :as drift])
+         One pass is not the fixpoint; `bb dev-compiler` runs the usual two.
+         See docs/bootstrap.md."
    :depends [-check-nostrand]
-   :task (do
-           (drift/touch-dlls!)
-           ;; magic.api/compile-file skips DLLs that already exist on disk, so
-           ;; delete bootstrap/ first to force re-compilation.
-           (fs/delete-tree (fs/file "magic-compiler" "bootstrap"))
-           (apply nos/nos! "build/bootstrap" *command-line-args*)
-           (shell "dotnet build -t:Bootstrap;MagicUnity")
-           (drift/record!))}
+   :task (nos/bootstrap! *command-line-args*)}
 
   refresh-stdlib
-  {:doc "Recompile every committed stdlib clojure.*.clj.dll from source, redeploy to nostrand/references/, nostrand/bin/Release/net471/, and magic-unity Export, then re-record dll-sources.edn.
-         Use after editing any magic-compiler/src/stdlib/**/*.clj: this owns every stdlib namespace outside the clojure.core family, clojure.string, clojure.set and clojure.walk included, and produces the same bytes the bootstrap would.
-         The clojure.core family (core, its 6 (in-ns 'clojure.core) sub-files, core.protocols, clr.io) needs `bb bootstrap`, as do the compiler's own magic.* and mage DLLs."
+  {:doc "Recompile every committed stdlib clojure.*.clj.dll from source, redeploy to nostrand/references/, the built host, and magic-unity Export, then re-record dll-sources.edn.
+         Use after editing any magic-compiler/src/stdlib/**/*.clj.
+         Owns every stdlib namespace outside the clojure.core family; every other committed DLL belongs to `bb bootstrap`.
+         See docs/bootstrap.md."
    :requires ([magic.drift :as drift])
    :depends [-check-nostrand]
    :task (do (drift/touch-dlls!)
@@ -66,42 +64,46 @@
 
   gen-unity-dual
   {:doc "Regenerate the magic-unity-dual UPM package from magic-unity: byte-identical except the runtime *.clj.dll are constrained to !UNITY_EDITOR and the package is renamed.
-         Run after any magic-unity change; the output is committed and drift-checked. See docs/unity-integration.md."
+         Run after any magic-unity change.
+         The output is committed and drift-checked.
+         See docs/unity-integration.md."
    :requires ([magic.unity :as unity])
    :task (println "Generated magic-unity-dual -" (unity/gen-dual!)
                   "runtime plugins constrained to !UNITY_EDITOR")}
 
   check-drift
   {:doc "Regenerate everything generated (callsite .g.cs, stdlib .clj.dll, dll-sources.edn, UPM version, dual variant) and fail if any checked path differs from HEAD.
-         Committed DLLs are byte-diffed; run after a fresh `bb build` so the bootstrap set is covered too, as CI does.
-         `bb check-drift skip-dlls` checks the dll-sources.edn source hashes instead: the fallback for an environment that fails to reproduce the bytes.
+         Committed DLLs are byte-diffed.
+         Run after a fresh `bb build` so the bootstrap set is covered too, as CI does.
          See docs/deterministic-compilation.md."
    :requires ([magic.drift :as drift])
    :depends [regen-callsites refresh-stdlib sync-upm-version]
-   :task (drift/check! (= "skip-dlls" (first *command-line-args*)))}
+   :task (drift/check!)}
 
   ;; ============================================================
   ;; Test + dev loops
   ;; ============================================================
 
   test
-  {:doc "Run the magic-compiler test suite. `bb test magic.test.fn magic.test.reify` runs specific namespaces. Requires built nostrand."
+  {:doc "Run the magic-compiler test suite.
+         `bb test magic.test.fn magic.test.reify` runs specific namespaces."
    :depends [-check-nostrand]
    :task (if (seq *command-line-args*)
            (apply nos/nos! "test/run" *command-line-args*)
            (nos/nos! "test/all"))}
 
-  dev-runtime
-  {:doc "After editing C# in clojure-runtime/ or magic-runtime/: rebuild runtimes + test. No bootstrap."
-   :depends [build-runtime test]}
-
   dev-callsites
-  {:doc "After editing magic-runtime/Magic.Runtime.Callsites/*.mustache: regen + rebuild runtimes + test."
-   :depends [regen-callsites build-runtime test]}
+  {:doc "After editing magic-runtime/Magic.Runtime.Callsites/*.mustache: regen the .g.cs, then rebuild the runtimes.
+         A C# edit with no template change is just `bb build-runtime`."
+   :depends [regen-callsites build-runtime]}
 
   dev-compiler
-  {:doc "After editing magic-compiler/src/**/*.clj: bootstrap + test. Slow. Redeployed DLLs that differ in git status are real changes; commit them with the source fix."
-   :depends [bootstrap test]}
+  {:doc "After editing magic-compiler/src/magic/**/*.clj or mage/src/: two bootstrap passes, since only pass 2 is the fixpoint.
+         Slow.
+         Extra args go to both passes."
+   :depends [-check-nostrand]
+   :task (do (nos/bootstrap! *command-line-args*)
+             (nos/bootstrap! *command-line-args*))}
 
   ;; ============================================================
   ;; Inspect / debug
@@ -109,7 +111,8 @@
 
   pipeline
   {:doc "Walk a Clojure form through reader -> AST -> symbolic IL.
-         Prints form, macroexpand, AST skeleton, type summary, and flattened opcode listing; dumps EDN to <out>/ (default magic-compiler/target).
+         Prints form, macroexpand, AST skeleton, type summary, and flattened opcode listing.
+         Dumps EDN to <out>/ (default magic-compiler/target).
          Options: :out <dir>, :sections '#{...}' subset of #{:form :macroexpand :ast :types :il :ast-edn :il-edn :tree-edn}."
    :requires ([magic.log :as log])
    :depends [-check-nostrand]
@@ -129,8 +132,10 @@
    :task (nos/nos! "repl")}
 
   prepl-server
-  {:doc "Start a socket prepl server (io-prepl) on a warm MAGIC runtime, like an nREPL for dev. Blocks.
-         Default port 5555; override: bb prepl-server 5560. Send forms from another shell with `bb prepl-eval`."
+  {:doc "Start a socket prepl server (io-prepl) on a warm MAGIC runtime, like an nREPL for dev.
+         Blocks.
+         Default port 5555; override: bb prepl-server 5560.
+         Send forms from another shell with `bb prepl-eval`."
    :depends [-check-nostrand]
    :task (apply nos/nos! "preplserver/start" *command-line-args*)}
 
@@ -146,8 +151,10 @@
 
   coexist-noise
   {:doc "Headless coexistence-noise repro on unity-examples/magic-unity-coexist.
-         `bb coexist-noise` tests the dual variant (expect 0 narration lines, the shipped fix); `bb coexist-noise magic-only` tests the default variant (expect 37 lines, the problem).
-         Needs Unity 2022.3.62f3 with no GUI editor holding the project; details in magic.unity/coexist-noise!."
+         `bb coexist-noise` tests the dual variant: expect 0 narration lines, the shipped fix.
+         `bb coexist-noise magic-only` tests the default variant: expect 37 lines, the problem.
+         Needs Unity 2022.3.62f3 with no GUI editor holding the project.
+         Details in magic.unity/coexist-noise!."
    :requires ([magic.unity :as unity])
    :depends [gen-unity-dual]
    :task (unity/coexist-noise! (or (first *command-line-args*) "dual"))}
@@ -166,12 +173,14 @@
    :task (release/outdated!)}
 
   verify-dist
-  {:doc "Verify release artifacts are present and `nos version` works. Run before tagging."
+  {:doc "Verify release artifacts are present and `nos version` works.
+         Run before tagging."
    :requires ([magic.release :as release])
    :task (release/verify-dist!)}
 
   release-tarball
-  {:doc "Build the nos release tarball under target/ and smoke-test it. Run by the release workflow on a tag push."
+  {:doc "Build the nos release tarball under target/ and smoke-test it.
+         Run by the release workflow on a tag push."
    :requires ([magic.release :as release])
    :depends [build]
    :task (release/release-tarball!)}

--- a/bb/magic/drift.clj
+++ b/bb/magic/drift.clj
@@ -1,10 +1,10 @@
 (ns magic.drift
   "The drift check and its dll-sources.edn manifest: the SHA256 of the .clj
    source behind each committed reference DLL, re-recorded by refresh-stdlib /
-   bootstrap. check-drift fails when it differs from HEAD, meaning a source
-   was edited without refreshing its DLL. The check hashes sources only, no
-   compiler run, so it also works in an environment whose toolchain cannot
-   reproduce the committed DLL bytes (the check-drift skip-dlls fallback)."
+   bootstrap. check-drift fails when a checked path differs from HEAD, meaning
+   a source was edited without refreshing its DLL. This namespace also stamps
+   the DLL mtimes from that manifest: a source that still hashes gets its DLL
+   stamped newer, so the loader takes the committed bytes over recompiling."
   (:require [babashka.fs :as fs]
             [babashka.tasks :refer [shell]]
             [clojure.edn]
@@ -101,23 +101,17 @@
    checked path differs from HEAD. Committed DLLs are byte-diffed, except
    Export's Clojure.dll and Magic.Runtime.dll: they embed a git-describe
    SourceRevisionId (csproj SetSourceRevisionId target), so their bytes are
-   commit-dependent by design and are restored from HEAD instead. skip-dlls?
-   restores all committed DLLs and relies on the dll-sources.edn source
-   hashes: the fallback for an environment that fails to reproduce the bytes."
-  [skip-dlls?]
-  (let [checked-paths (cond-> ["magic-runtime/Magic.Runtime/Generated"
-                               manifest-path
-                               "magic-unity/package.json"
-                               "magic-unity-dual"]
-                        (not skip-dlls?)
-                        (conj "nostrand/references"
-                              "magic-unity/Runtime/Infrastructure/Export"))
-        _ (apply shell "git" "checkout" "--"
-                 (if skip-dlls?
-                   ["nostrand/references/"
-                    "magic-unity/Runtime/Infrastructure/Export/"]
-                   ["magic-unity/Runtime/Infrastructure/Export/Clojure.dll"
-                    "magic-unity/Runtime/Infrastructure/Export/Magic.Runtime.dll"]))
+   commit-dependent by design and are restored from HEAD instead."
+  []
+  (let [checked-paths ["magic-runtime/Magic.Runtime/Generated"
+                       manifest-path
+                       "magic-unity/package.json"
+                       "magic-unity-dual"
+                       "nostrand/references"
+                       "magic-unity/Runtime/Infrastructure/Export"]
+        _ (shell "git" "checkout" "--"
+                 "magic-unity/Runtime/Infrastructure/Export/Clojure.dll"
+                 "magic-unity/Runtime/Infrastructure/Export/Magic.Runtime.dll")
         _ (unity/gen-dual!)
         {:keys [out]} (apply shell {:continue true :out :string}
                              "git" "status" "--porcelain" "--" checked-paths)]

--- a/bb/magic/nos.clj
+++ b/bb/magic/nos.clj
@@ -1,9 +1,11 @@
 (ns magic.nos
-  "Invocation of the repo-built Nostrand binary, plus the prepl client."
+  "Invocation of the repo-built Nostrand binary, the bootstrap pass, and the
+   prepl client."
   (:require [babashka.fs :as fs]
             [babashka.tasks :refer [shell]]
             [clojure.java.io :as io]
             [clojure.string :as str]
+            [magic.drift :as drift]
             [magic.log :as log]))
 
 (def exe "nostrand/bin/Release/net471/NostrandMain.exe")
@@ -19,6 +21,20 @@
   "Run a Nostrand task from magic-compiler/ with the repo-built binary."
   [task & args]
   (apply shell {:dir "magic-compiler"} "mono" (str "../" exe) task args))
+
+(defn bootstrap!
+  "One bootstrap pass: compile the compiler with whatever compiler is currently
+   in references/, deploy the result over it, re-record the manifest. The
+   compiler that ran was the previous one, so one pass is not the fixpoint and
+   a compiler change needs two calls."
+  [args]
+  (drift/touch-dlls!)
+  ;; magic.api/compile-file skips DLLs that already exist on disk, so
+  ;; delete bootstrap/ first to force re-compilation.
+  (fs/delete-tree (fs/file "magic-compiler" "bootstrap"))
+  (apply nos! "build/bootstrap" args)
+  (shell "dotnet build -t:Bootstrap;MagicUnity")
+  (drift/record!))
 
 (defn prepl-eval!
   "Send one form to a running prepl server and print the reply maps until :ret."

--- a/bb/magic/unity.clj
+++ b/bb/magic/unity.clj
@@ -54,9 +54,9 @@
           (println "Updated magic-unity/package.json version to" version)))))
 
 (defn gen-dual!
-  "Regenerate magic-unity-dual as a verbatim copy of magic-unity with the runtime
-   clj.dll plugins constrained to !UNITY_EDITOR and the package renamed. Returns
-   the number of constrained plugins."
+  "Regenerate magic-unity-dual as a byte-for-byte copy of magic-unity with the
+   runtime clj.dll plugins constrained to !UNITY_EDITOR and the package renamed.
+   Returns the number of constrained plugins."
   []
   (fs/delete-tree dual-pkg)
   (shell "cp" "-R" default-pkg dual-pkg)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,265 @@
+# MAGIC architecture
+
+Magic is a monorepo for the compiler and its tooling.
+
+## Components Overview
+
+| Component | Description | Language |
+|-----------|-------------|----------|
+| [clojure-runtime](../clojure-runtime) | Clojure's data model in C#: persistent collections, keywords, vars, the reader. Every compiled DLL runs on it. | C# |
+| [magic-runtime](../magic-runtime) | Resolves the interop calls whose types are only known at run time, caching each call site. Emits no IL at run time, which is what IL2CPP requires. | C# |
+| [mage](../mage) | MSIL as Clojure data, so bytecode can be built and rewritten as plain values before it is emitted. | Clojure |
+| [magic-compiler](../magic-compiler) | The compiler: Clojure forms to MSIL. Also holds the standard library sources it compiles. | Clojure |
+| [nostrand](../nostrand) | The `nos` CLI. Boots the runtime, loads the compiler DLLs, resolves dependencies, runs build, test and REPL tasks. | C# + Clojure |
+| [magic-unity](../magic-unity) | The UPM package Unity loads at play time: the prebuilt runtime plus the IL2CPP pre-build step. | C# |
+| [magic-unity-smoke](../unity-examples/magic-unity-smoke) | Unity project that runs the same checks under Mono and under IL2CPP, catching the AOT-only bugs Mono cannot reach. Run by hand on Unity `2022.3.62f3`. | Clojure + C# |
+| [magic-unity-coexist](../unity-examples/magic-unity-coexist) | Unity project that runs MAGIC and ClojureCLR side by side, MAGIC for players and ClojureCLR for editor hot reload. | C# |
+
+The diagram below shows what gets built from what, and what ships.
+
+```mermaid
+flowchart LR
+    subgraph cssrc["C# sources"]
+        cs["clojure-runtime<br/>magic-runtime"]
+    end
+
+    subgraph cljsrc["Clojure sources"]
+        mage["mage"]
+        cljc["magic-compiler/src/magic"]
+        ta["clojure.tools.analyzer<br/>git dep pinned in magic-compiler/deps.edn"]
+        cljs["magic-compiler/src/stdlib"]
+    end
+
+    subgraph out["Build output"]
+        rt["the runtime:<br/>Clojure.dll<br/>Magic.Runtime.dll"]
+        cdll["36 compiler .clj.dll"]
+        sdll["37 stdlib .clj.dll"]
+    end
+
+    subgraph ship["Shipped"]
+        nos["nos CLI"]
+        upm["magic-unity"]
+    end
+
+    cs -->|"dotnet build"| rt
+    mage --> cdll
+    cljc -->|"compiled by MAGIC"| cdll
+    ta --> cdll
+    cljs -->|"compiled by MAGIC"| sdll
+
+    rt --> nos
+    cdll --> nos
+    sdll --> nos
+    rt --> upm
+    sdll --> upm
+```
+
+Consumers only need 2 things:
+ - a `nos` CLI that developers install
+ - a Unity package which a game loads at play time
+
+## The runtime
+
+Compiled Clojure cannot run on its own.
+
+Something has to hold the collections, intern the keywords, resolve the vars, and handle the calls the compiler could not resolve ahead of time. That is the runtime, and it ships as two DLLs.
+
+The diagram below shows where each piece comes from, and what was left behind on the way.
+
+```mermaid
+flowchart LR
+    clr["ClojureCLR<br/>runtime + C# compiler"]
+    gone["DLR compiler, Reflector<br/>they build IL at run time"]
+
+    subgraph cr["clojure-runtime"]
+        keep["collections, reader,<br/>Vars, RT"]
+        seam["added: compile, eval, load<br/>as bindable vars"]
+    end
+
+    subgraph mr["magic-runtime"]
+        hand["hand-written: Binder, Dispatch,<br/>Magic.Function interfaces"]
+        tmpl["5 .mustache templates"]
+        gen["Magic.Runtime.Callsites<br/>net8.0 generator"]
+        gcs["97 committed .g.cs<br/>one file per shape and arity"]
+    end
+
+    subgraph run["The runtime"]
+        cljdll["Clojure.dll"]
+        magdll["Magic.Runtime.dll"]
+    end
+
+    clr -->|"fork ✔️"| keep
+    clr -->|"dropped ❌"| gone
+    keep --> cljdll
+    seam --> cljdll
+    tmpl --> gen --> gcs --> magdll
+    hand --> magdll
+
+    ship["loaded by nos at startup,<br/>and by Unity in the editor and in players"]
+
+    cljdll --> ship
+    magdll --> ship
+```
+
+ClojureCLR already had a runtime, and rewriting it would have been a waste of time, so Ramsey Nasser forked it. What the fork could not keep was the compiler that comes with it.
+
+Upstream ClojureCLR writes IL while the program runs. Each form becomes an expression tree, and the tree goes to `Reflection.Emit`, which turns it into runnable code on the spot. Interop works the same way. The first time a call site runs, the [DLR](https://learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/dynamic-language-runtime-overview) compiles a delegate specialized to the argument types it just saw, guards it with a type check, and caches it on the site.
+
+So the compiler ships with the program, and the writing happens wherever the program runs. On a desktop that is a good trade. On iOS it is illegal, because a memory page may never be writable and executable at once. Under IL2CPP it is not even available, because an AOT toolchain only translates the IL that exists at build time and ships no `Reflection.Emit` to produce more. That constraint is why MAGIC exists, see [Why MAGIC](./why-magic.md).
+
+The fork therefore keeps everything that holds values and drops everything that writes code. `CljCompiler/` goes from 72 files upstream down to 3, and most of what went is one directory: `Ast/`, the 65 expression-tree node classes. `Reflector`, the class behind runtime reflective calls, is gone. The `DynamicLanguageRuntime` package reference went with them, and that is the part that makes the result shippable, because no `Reflection.Emit` path survives in `Clojure.dll`. One expression-tree call remains, `GenDelegate.Create` behind `gen-delegate`. It survives because expression trees fall back to an interpreter on AOT platforms.
+
+`clojure.core` calls into the compiler at four entry points: `eval`, `macroexpand-1`, and RT's load and compile paths. The fork turns each one into a dynamic var that throws until bound (`*eval-form-fn*`, `*macroexpand-1-fn*`, `*load-file-fn*`, `*compile-file-fn*`). `nostrand` fills the gap at startup by binding them to `magic.api`, and MAGIC becomes the compiler without `clojure.core` knowing whose compiler it is.
+
+Dispatch needs a replacement too, and that is `magic-runtime`. Rather than compiling a delegate per call site, every call site shape exists ahead of time as a generated type, and each site caches the argument types it has already seen. Same idea as the DLR's inline caches, minus the code generation.
+
+The two DLLs are inseparable in practice. `nos` loads them at startup, Unity loads them at play time, and every compiled `.clj.dll` names both in its assembly references. That is why the diagram shows them as one box.
+
+## The compiler
+
+The compiler turns a Clojure form into MSIL, and it does that in three steps.
+
+The reader hands over data with no meaning attached. `(let [x 1] (+ x 2))` is a list holding a symbol, a vector and another list. Nothing in it says the `x` in the body is the `x` in the brackets. So the steps are as follows:
+1. works out what the form means
+2. works out which CLR types are involved
+3. writes the instructions.
+
+```mermaid
+flowchart LR
+    form["a Clojure form<br/>(.Now DateTime)"]
+    ta["clojure.tools.analyzer<br/>contrib library, host-agnostic"]
+
+    subgraph mc["magic-compiler"]
+        clr["magic.analyzer<br/>CLR passes: types,<br/>host forms, intrinsics"]
+        core["magic.core<br/>one compiler fn<br/>per AST node type"]
+    end
+
+    subgraph mg["mage"]
+        emit["il/emit!"]
+    end
+
+    dll[".clj.dll"]
+
+    form --> ta
+    ta -->|"AST: scope resolved"| clr
+    clr -->|"AST: types resolved"| core
+    core -->|"symbolic IL, still data"| emit
+    emit -->|"MSIL bytes"| dll
+```
+
+The analyzer resolves that list into a tree where every node is labelled: `let*` is a special form, `x` is a local, the body's `x` points back at its binding. None of that depends on the host, so it comes from `clojure.tools.analyzer`, the contrib library every Clojure implementation can share. What the library will not do is CLR work: whether `DateTime` names a type, which overload of `.Add` applies, what type an expression produces. Those passes are `magic.analyzer`. They turn a host-agnostic tree into one a CLR backend can use.
+
+That split is not MAGIC's invention. Contrib had already laid it out, and MAGIC fills in the CLR column:
+
+| Job | JVM | MAGIC |
+|---|---|---|
+| host-agnostic analysis | `tools.analyzer` | `tools.analyzer`, the same library |
+| host-specific passes | `tools.analyzer.jvm` | `magic.analyzer` |
+| AST to bytecode | `tools.emitter.jvm` | `magic.core` + `mage` |
+
+`tools.analyzer.jvm` and `tools.emitter.jvm` together are a Clojure compiler written in Clojure. MAGIC is that idea aimed at the CLR, which is why it depends on the first row instead of reimplementing it.
+
+Once the tree knows its types, each node needs instructions. `magic.core` holds one function per node type, keyed by the `:op` the analyzer produced, and in MAGIC's vocabulary those functions are the compilers. They are small: the whole compiler for a static property is `(il/call (.GetGetMethod property))`. Each one is handed the map of all compilers and passes it down, so compiling a `do` form is just compiling its children. Spells work at this level too. A spell is a function from the compiler map to a new compiler map, so turning one on swaps in a specialized compiler for certain nodes and leaves the rest alone.
+
+A CLR compiler normally emits by calling `ilg.Emit(OpCodes.Ldstr, "hi")`, and the instruction exists only as a side effect: you cannot hold it, inspect it, or change your mind about it. `mage` makes the same instruction a value. `(il/ldstr "hi")` returns a map, a tree of those maps describes an assembly, and `il/emit!` is the one function that walks the tree and produces bytes. Ramsey calls this symbolic bytecode. It is what lets the compilers return instructions instead of performing them, which is why one can be called in a REPL and read, and why `bb pipeline` can show the IL for a form without running it.
+
+`mage` is built on `System.Reflection.Emit`, the API IL2CPP does not implement. That is not a contradiction. `mage` runs on a developer's machine at build time, under Mono, and never ships in the Unity package. Only the `.clj.dll` it wrote travels to the device, and nothing in that file emits anything. The difference between MAGIC and ClojureCLR is not which API each uses, it is when each runs it.
+
+## Nostrand
+
+Everything so far is unusable on its own.
+
+The compiler is itself compiled Clojure, so something has to load it before any Clojure can run. `clojure.core` ships with its compiler slots empty, so something has to fill them. The CLR has no `clojure` CLI and no dependency resolution either. `nostrand` answers all of that. It is `NostrandMain.exe`, and it is what `nos` runs.
+
+It is written in two languages, and where the line between them falls is the whole story. Everything that has to happen before Clojure works is C#. Everything after it is Clojure.
+
+```mermaid
+flowchart TD
+    cmd["you type: nos build"]
+
+    subgraph cs["written in C#, because no Clojure exists yet"]
+        a["load Clojure.dll, Magic.Runtime.dll,<br/>and every .clj.dll next to them"]
+        b["start the runtime, then<br/>clojure.core and magic.api"]
+        c["fill clojure.core's empty<br/>compiler slots with magic.api"]
+    end
+
+    subgraph cl["written in Clojure, because now MAGIC runs"]
+        d["load paths and assembly loading"]
+        e["read deps.edn, fetch git deps"]
+        f["find your task and call it"]
+    end
+
+    cmd --> a --> b --> c --> d --> e --> f
+```
+
+The C# half is `Nostrand.cs`. It loads every `.clj.dll` sitting next to `Clojure.dll`, starts the runtime, initialises `clojure.core` and `magic.api`, then fills the compiler slots. Four of them, `*compile-file-fn*`, `*load-file-fn*`, `*eval-form-fn*` and `*macroexpand-1-fn*`, are pointed at `magic.api`. The fifth, `*load-fn*`, is pointed back into `clojure.core`. After those five lines `compile`, `eval` and `load-file` work, and nothing that calls them knows which compiler answered.
+
+The Clojure half is under `nostrand/`. It puts source paths on the load path, reads `deps-clr.edn`/`deps.edn` and fetches git dependencies, defines the tasks, and hosts the REPLs. None of it could have run a moment earlier. [CLR dependency resolution](./clr-dependency-files.md) and [the nos CLI](./nos-cli.md) cover what it does.
+
+The output directory makes this concrete. `nostrand/bin/Release/net471/` holds `NostrandMain.exe`, `Clojure.dll` and `Magic.Runtime.dll`, and then two kinds of Clojure side by side: 73 compiled `.clj.dll`, and nostrand's own Clojure (`core.clj`, `tasks.clj`, `repl.clj`, the deps code) as plain source.
+
+They differ because three separate compilations happen, at three different times.
+
+| What is compiled | When | Where the result goes |
+|---|---|---|
+| the compiler and the stdlib | rarely, during a bootstrap | `nostrand/references/`, committed to git |
+| nostrand's own `.clj` | every `nos` startup | memory only, gone when the process exits |
+| your project | when you run `nos build` | `.clj.dll` next to your sources |
+
+The compiler is a DLL out of necessity: it cannot compile itself into existence, so [the bootstrap](./bootstrap.md) builds it rarely and the result is committed, which is why `references/` is in git. Nostrand's Clojure has no such constraint, because by the time it loads MAGIC is already running, and source is the cheaper form: a committed DLL would need a refresh after every task edit and every compiler change, while a fresh in-memory compile of a thousand lines is fast and can never be stale.
+
+## The Unity package
+
+Unity never compiles Clojure.
+
+You compile first with `nos`, which writes `.clj.dll` into `Assets/Plugins/Magic/`, and Unity loads them as ordinary .NET assemblies. So the package ships a runtime and no compiler.
+
+```mermaid
+flowchart TD
+    nos["nos dotnet/build,<br/>outside Unity"] --> asm
+
+    subgraph asm["What Unity loads"]
+        yours["your .clj.dll"]
+        pkg["the package's runtime:<br/>Clojure.dll, Magic.Runtime.dll,<br/>37 stdlib .clj.dll"]
+    end
+
+    asm -->|"Play mode in the editor"| play["loaded as they are,<br/>the Cecil rewrite never fires"]
+    asm -->|"editor, when ClojureCLR<br/>is in the project"| coex["every fork .clj.dll imported with<br/>editor loading off"]
+    asm -->|"any player build"| pre["Editor/ rewrites every .clj.dll<br/>in place, with Mono.Cecil"]
+    pre -->|"Mono backend"| mono["workarounds removed,<br/>packaged as IL"]
+    pre -->|"IL2CPP backend"| cpp["workarounds added, then<br/>transpiled to C++ and native"]
+```
+
+The two backends in the diagram are Unity's scripting backend setting, chosen per build target. Mono ships the IL to the device and JIT-compiles it there. IL2CPP translates all the IL to C++ at build time and compiles that to a native binary, which is why nothing may be emitted at run time.
+
+The runtime side is small. `Runtime/Magic.Unity.cs` is the `Magic.Unity.Clojure` API that C# scripts call, `Boot`, `Require` and `GetVar`, and `Runtime/Infrastructure/Export/` holds the prebuilt runtime plus the whole stdlib. In Play mode no build callback fires, and the assemblies load and run as they are.
+
+The editor side, nine files, mostly exists because IL2CPP rejects IL that MAGIC emits legally. `Editor/MagicPreprocessor.cs` hooks `IPreprocessBuildWithReport`, so on every player build, under either backend, it hands each assembly to `IL2CPPWorkarounds` to be walked with Mono.Cecil. The backend decides what the walk does, not whether it happens: on IL2CPP the workarounds are added, on Mono any left over from a previous IL2CPP build are removed.
+
+Three passes do the work. `EliminateUnreachableInstructions` strips dead IL the AOT linker chokes on. `GenerateGenericWorkaroundMethods` synthesises the generic instantiations IL2CPP's sharing pass needs to see ahead of time. `LinkXmlGenerator` adds `<preserve>` entries so managed stripping leaves the runtime alone.
+
+That rewrite happens in place. `IL2CPPWorkarounds` writes a temporary file, deletes the original and moves the new bytes over it, so after any player build the DLLs in `Export/` are Cecil output rather than compiler output. This is unconditional, and it happens on Mono builds too: reading and writing an assembly with Cecil rebuilds its metadata tables and layout, so the bytes differ even when no instruction changed. Deterministic compilation says nothing about it, because the mutation happens downstream of the compiler. Committing that directory after a build, without restoring it first, ships the wrong bytes. [The bootstrap](./bootstrap.md) covers getting back to a clean state.
+
+A project can also keep ClojureCLR in the editor for hot reload and run MAGIC only in players. The package detects that on its own: when a strong-named `Clojure.dll` sits under `Assets`, every `.clj.dll` referencing the fork, the package's and yours, is reimported with editor loading off, and restored once the foreign copy leaves. What the two runtimes need from each other, and how a project sets that up, is [Unity integration](./unity-integration.md).
+
+## The example Unity projects
+
+Some bugs only appear inside a real Unity build, so two whole Unity projects live in `unity-examples/` to catch them. One catches a class of bug nothing else can reach, the other demonstrates a setup real projects ship with. Both are pinned to Unity `2022.3.62f3`, both are run by hand, and neither is in CI, because both need a Unity install.
+
+[`magic-unity-smoke`](../unity-examples/magic-unity-smoke) catches bugs that only exist after ahead-of-time compilation. Seven Clojure suites cover value types, `letfn`, polymorphism, control flow, reading and printing, the 1.10 stdlib additions, and interop. That last one is written as `.cljr`, so the source-extension handling gets exercised too.
+
+The point is the comparison. `nos dotnet/run-tests` runs the suites under Mono in seconds, and `MAGIC/Smoke/Build & Run IL2CPP` runs them inside a built player. A check that passes under Mono and fails in the player is an IL2CPP bug, and nowhere else in the repo can that distinction be drawn. `SmokeBootstrap` forces the backend to IL2CPP and managed stripping to Disabled when the editor loads, so the project cannot drift back to a configuration that would hide those bugs.
+
+[`magic-unity-coexist`](../unity-examples/magic-unity-coexist) shows how to run both compilers in one Unity project, which is what a shipping game actually wants.
+
+The reason is hot reload. MAGIC compiles ahead of time, so changing a function means recompiling and reloading the domain. ClojureCLR loads `.clj` from disk and can redefine a var the moment you save. ClojureCLR in turn cannot ship to iOS, which is the whole reason MAGIC exists. So each runs where it is strong: ClojureCLR drives the editor, MAGIC compiles what players run. The project vendors ClojureCLR and its dependencies, the DLR included, so that arrangement can be exercised here instead of only inside a consumer project, and it runs headless from a `bb` task.
+
+Making the two share a project also took fixes on the ClojureCLR side, carried by [`flybot-sg/clojure-clr`](https://github.com/flybot-sg/clojure-clr), a maintained 1.11 fork that the Unity package will soon embed.
+
+## The bootstrap
+
+MAGIC is a Clojure compiler written in Clojure, so compiling it needs a working MAGIC.
+
+The way out of that circle is `nostrand/references/`: build the host against the committed DLLs, use it to compile the new compiler, copy the result back over them, rebuild the host. The `nos` you end up with runs the compiler you just built. One consequence bites often: the first pass compiled your change using the old compiler, so a compiler change needs two rebuilds before the bytes settle.
+
+So the DLLs are committed out of necessity, not preference. Without them a fresh clone has no compiler to start from, and nothing can be built at all. The risk that comes with them is a stale binary nobody notices: a build that fails halfway leaves the old DLLs in place, and those are exactly the ones the next run loads. Compilation is deterministic, so a byte diff in CI catches that. [The bootstrap](./bootstrap.md) has the rules, and [deterministic compilation](./deterministic-compilation.md) covers what makes them hold.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,0 +1,357 @@
+# The bootstrap
+
+MAGIC compiles Clojure source into .NET assemblies. You hand it `.clj` files, it emits MSIL and packages that into a `.dll` the CLR loads and runs like any C# output. One namespace becomes one assembly, named after it: `magic.core` compiles to `magic.core.clj.dll`. Nothing is compiled at run time, which is the whole point ([why MAGIC](./why-magic.md)).
+
+MAGIC is itself written in Clojure. So the compiler is just another Clojure program that MAGIC compiles into .NET assemblies, and the version you run today was compiled by the version before it. That is **bootstrapping**, and it is how the compiler moves forward.
+
+Improving the compiler therefore means three steps, always in that order: 
+1. edit the Clojure sources under `magic-compiler/src/`
+2. compile them using the committed DLLs
+3. commit the source fix and the fresh DLLs. 
+
+Keeping the DLLs in git buys two things. A clone gets a working compiler with no other toolchain involved. And the compiler gets a history: `git show <sha>:nostrand/references/magic.core.clj.dll` is the compiler as it stood at that commit, which makes bisecting a compiler regression cheap. The commit convention is what holds that together, a source fix plus a paired `chore(bootstrap): refresh ...` for the binaries it regenerated ([CONTRIBUTING](../CONTRIBUTING.md)).
+
+Before it could compile itself, MAGIC was compiled by another compiler. Until October 2020 the sources were compiled by [ClojureCLR](https://github.com/clojure/clojure-clr), whose own compiler is written in C#, and nothing was kept.
+
+```mermaid
+flowchart LR
+    src["magic-compiler/src<br/>the compiler, in Clojure"]
+
+    subgraph era1["until Oct 2020: ClojureCLR compiles MAGIC"]
+        clr["ClojureCLR's compiler<br/>written in C#35;"]
+        c1(["compile"])
+        mem["MAGIC, in memory only<br/>redone at every startup"]
+        clr --> c1 --> mem
+    end
+
+    subgraph era2["since Oct 2020: MAGIC compiles MAGIC"]
+        refs["nostrand/references/<br/>73 committed .clj.dll<br/>the previous MAGIC"]
+        c2(["compile"])
+        out["fresh .clj.dll<br/>the next MAGIC"]
+        refs --> c2 --> out
+        out -->|"committed back over references/"| refs
+    end
+
+    src --> c1
+    src --> c2
+    mem ==>|"produced the first committed set"| refs
+```
+
+ClojureCLR rebuilt MAGIC from source at every startup and kept nothing, so no MAGIC output existed in the tree at all. Self-hosting began the day that output was committed instead, and the 73 `.clj.dll` in `nostrand/references/` are what it grew into.
+
+## What is committed, and why
+
+Two directories hold committed `.clj.dll`, and only one of them holds a compiler.
+
+| Directory | Holds | Loaded by |
+|---|---|---|
+| `nostrand/references/` | 73 `.clj.dll`: the compiler (26 `magic.*` plus `mage.core`), its analyzer dependency (9 `clojure.tools.analyzer.*`), and the stdlib (37 `clojure.*`) | `nos`, at every startup |
+| `magic-unity/Runtime/Infrastructure/Export/` | the same 37 stdlib `.clj.dll`, plus `Clojure.dll` and `Magic.Runtime.dll` | Unity, at play time and in players |
+
+No compiler ships to Unity, because Unity never compiles Clojure. You compile with `nos` first, and Unity loads the result as ordinary .NET assemblies ([Unity integration](./unity-integration.md)).
+
+A third copy exists and is not committed: `nostrand/bin/Release/net471/`. `NostrandMain.csproj` lists `references/*.dll`, so building the host copies all 73 there, next to `NostrandMain.exe`. That is the set a running `nos` actually loads, and `references/` is the source of truth that feeds it.
+
+`Nostrand.cs` picks them up at startup, in one function. Here is the Nostrand boot:
+
+```csharp
+static void BootClojureAndNostrand()
+{
+    // the committed compiler, loaded as plain assemblies:
+    // every .clj.dll sitting next to Clojure.dll
+    var assemblyPath = Path.GetDirectoryName(Assembly.Load("Clojure").Location);
+    foreach(var cljDll in Directory.EnumerateFiles(assemblyPath, "*.clj.dll"))
+    {
+        Assembly.LoadFile(cljDll);
+    }
+
+    // run their Initialize methods. Clojure exists after this, and so does MAGIC
+    RT.Initialize(doRuntimePostBoostrap: false);
+    RT.TryLoadInitType("clojure/core");
+    RT.TryLoadInitType("magic/api");
+
+    // the fork has no compiler, so clojure.core's compile, eval and load slots
+    // are empty. binding them to magic.api is what makes them work, and nothing
+    // that calls them ever knows whose compiler answered
+    RT.var("clojure.core", "*load-fn*").bindRoot(RT.var("clojure.core", "-load"));
+    RT.var("clojure.core", "*eval-form-fn*").bindRoot(RT.var("magic.api", "eval"));
+    RT.var("clojure.core", "*load-file-fn*").bindRoot(RT.var("magic.api", "runtime-load-file"));
+    RT.var("clojure.core", "*compile-file-fn*").bindRoot(RT.var("magic.api", "runtime-compile-file"));
+    RT.var("clojure.core", "*macroexpand-1-fn*").bindRoot(RT.var("magic.api", "runtime-macroexpand-1"));
+
+    // nostrand's own Clojure: compiled into memory by MAGIC, on every single run,
+    // which is why none of it is committed
+    RT.var("clojure.core", "*load-fn*").invoke("nostrand/core");
+    RT.var("clojure.core", "*load-fn*").invoke("nostrand/tasks");
+}
+```
+
+These 73 binaries are versioned like source, because for this compiler they are source: they are the only form of MAGIC that another MAGIC can be built from.
+
+Since **v0.10.0** rebuilding unchanged sources produces the same bytes on any machine, with the last two nondeterminism holes closed in **v0.11.0**. That is what makes a byte diff worth running: after a rebuild, `git status` lists exactly the DLLs your fix affected and nothing else, and CI runs the same diff on every pull request, so a stale binary fails the build. [Deterministic compilation](./deterministic-compilation.md) covers how that holds.
+
+## How to build the new DLLs
+
+`bb build` runs the loop once. It is a chain of MSBuild targets moving bytes between directories, and `nostrand/references/` is both the first input and the last output.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant refs as references/
+    participant host as nostrand host
+    participant rt as runtime bin/
+    participant boot as bootstrap/
+    participant exp as Export/
+
+    Note over refs,exp: bb build stamps every committed DLL's mtime, then -t:Clean wipes bin/ and bootstrap/
+    refs->>host: -t:Nostrand builds NostrandMain.exe against the committed 73
+    host->>rt: the same build compiles Clojure.dll and Magic.Runtime.dll from source
+    host->>boot: -t:Magic runs nos build/bootstrap, compiling src/ into 48 fresh .clj.dll
+    boot->>refs: -t:Bootstrap copies all 48 over the committed set
+    refs->>host: -t:Bootstrap rebuilds the host, which now runs the new compiler
+    boot->>exp: -t:MagicUnity copies the 12 stdlib .clj.dll
+    rt->>exp: -t:MagicUnity copies Clojure.dll and Magic.Runtime.dll
+```
+
+Steps 4 and 5 are the round trip. `nostrand/references/` builds the host, the host compiles `magic-compiler/src/` into `magic-compiler/bootstrap/`, which is gitignored, and `bootstrap/` is copied back over `references/`. The host is then built a second time from those new bytes, so the `nos` you end up with runs the compiler you just built.
+
+Two silent no-ops guard this path, both deliberate. `magic.api/compile-file` refuses to overwrite a DLL that already exists, and the MSBuild `Magic` target is skipped when `magic-compiler/bootstrap/` is already there. That is why the build runs `Clean` first, and why `bb bootstrap` deletes the directory by hand.
+
+### What gets compiled, and in what order
+
+48 namespaces get compiled in a fixed order. The order follows the require graph.
+
+The compile step in the middle is `magic-compiler/build.clj`. It names those 48, and they are the first four rows below. The fifth row is the rest of the 73, and no part of `bb build` touches it.
+
+| Group | Count | Owned by |
+|---|---|---|
+| the compiler: 26 `magic.*` plus `mage.core` | 27 | `bb bootstrap` |
+| `clojure.tools.analyzer.*`, a pinned git dependency compiled here rather than shipped | 9 | `bb bootstrap` |
+| `clojure.string`, `clojure.set`, `clojure.walk`, which the compiler requires | 3 | `bb refresh-stdlib` |
+| `clojure.core` and the 8 units compiled with it, last | 9 | `bb bootstrap` |
+| the rest of the stdlib (`pprint`, `spec`, `test`, `zip`, `datafy`, ...) | 25 | `bb refresh-stdlib` |
+
+Six of the nine in that fourth row are not libraries of their own, whatever their DLL names suggest. `core_proxy`, `core_print`, `genclass`, `core_deftype`, `gvec` and `core_clr` each open with `(in-ns 'clojure.core)`, so everything they define lands in `clojure.core`, and `core.clj` pulls them in with `(load ...)` exactly as on the JVM. One namespace, split across seven files, emitted as seven DLLs. The other two are real namespaces: `clojure.core.protocols`, which `core.clj` loads, and `clojure.clr.io`, which it requires.
+
+`clojure.core` goes last on purpose. Compiling it re-executes its top-level forms in the running image, which redefines `clojure.core/*load-paths*` and breaks `find-file` for everything after it.
+
+The bootstrap is not a cold boot. `Nostrand.cs` has already loaded all 73 DLLs and initialised `clojure.core` before `build.clj` starts, so nothing has to be built before its dependencies. What the order buys instead is that each namespace is compiled against dependencies the same run just recompiled, rather than a mix of fresh and committed ones, and that nothing recompiled early breaks the process doing the compiling. `clojure.core` last is the sharpest case of the second.
+
+## Which task to run
+
+Three tasks write committed DLLs, and each owns a different slice of the 73.
+
+`bb build` and `bb bootstrap` both produce the same 48 and deploy them the same way, with `dotnet build -t:Bootstrap;MagicUnity`. So steps 4 to 7 of the diagram above are the same for either. They differ in how they get there.
+
+| | `bb build` | `bb bootstrap` |
+|---|---|---|
+| Needs a working `nos` already | no, it builds one | yes, it fails early without one |
+| What it wipes | every `bin/` and `bootstrap/`, via `-t:Clean` | `magic-compiler/bootstrap/` only |
+| How it reaches the compiler | `-t:Nostrand` then `-t:Magic` | calls `nos build/bootstrap` directly |
+| Re-records `dll-sources.edn` | no | yes |
+| Takes extra arguments | no | yes, forwarded to `nos build/bootstrap` |
+
+Use `bb build` after a fresh clone, when there is no host to run yet. Use `bb bootstrap` for compiler work, which is most of the time. The forwarded arguments are how the `sparse-case` pass below is requested.
+
+`bb refresh-stdlib` owns 28, every namespace under `magic-compiler/src/stdlib/**/*.clj` outside the `clojure.core` family, and is what to run after editing one. It recompiles them and copies each into `references/`, the host's `bin/Release/net471/`, and `Export/` in one go. When a namespace fails to compile it deploys nothing and exits non-zero, so a partial refresh cannot pass for a complete one.
+
+`bb check-drift` therefore runs `refresh-stdlib` itself, and wants a fresh `bb build` in front of it. Between them, that is the only way to cover all 73.
+
+### Why `clojure.core` cannot be refreshed
+
+`bb refresh-stdlib` skips nine of the namespaces `build.clj` compiles, the `clojure.core` family, and the reason is `clojure.core` itself.
+
+Compiling a Clojure file means evaluating its top-level forms as you go, because later forms need the `def`s and macros the earlier ones made. `core.clj` contains this:
+
+```clojure
+(def ^:dynamic *load-paths*
+  (if load-code-from-filesystem?
+    [(System.IO.Path/GetDirectoryName (.Location (.Assembly clojure.lang.RT)))]
+    []))
+```
+
+One entry: the directory `Clojure.dll` sits in. Nostrand then pushes the project's source directories onto that vector at startup, and that is the only reason the compiler can find `magic-compiler/src/stdlib/clojure/pprint.clj` at all.
+
+So compiling `core.clj` re-executes that `def` in the live process and `*load-paths*` snaps back to the one-element vector. Every source path is gone, and the next namespace compiled in that process dies on "Could not locate ... on load path". That is why `clojure.core` goes last, and why no other flow may touch it.
+
+The six `(in-ns 'clojure.core)` sub-files are excluded with it, and so are `clojure.core.protocols` and `clojure.clr.io`, which `core.clj` pulls in: recompiling any of the eight re-emits `clojure.core`, which this flow cannot write.
+
+### Split namespaces compile as separate units
+
+`clojure.core` is not the only namespace split across files, and the split ones need care. `clojure/pprint/pretty_writer.clj` opens with `(in-ns 'clojure.pprint)` and is pulled in by `(load "pprint/pretty_writer")` from `pprint.clj`, which does the same for six other files.
+
+Neither obvious approach works. Compiling a sub-file on its own fails, because the parent has to run first and intern the vars its forms reference. Leaving it to the parent fails differently: the parent's `(load ...)` goes through the mtime rule further down, which hands back the existing DLL rather than emitting a new one. That is how six `pprint` sub-files and `core_clr` stayed frozen at their 2020 and 2022 bytes for years.
+
+`refresh.clj` handles it by reading each source's first meaningful line. Files starting with `(ns` compile first, as top-level units. The `(in-ns ...)` sub-files compile afterwards, each as its own explicit unit.
+
+## How many passes your change needs
+
+Some changes need one rebuild, most compiler changes need two, a baked-value change needs two with a spell on the first, and a signature change needs two rounds of two. A **pass** is one complete run of the build task, start to finish.
+
+One question decides the count: **how much of the compiler sits downstream of what you changed?** Change a leaf and one pass is enough. Change something the compiler is built out of and one pass cannot be trusted, because that pass ran the old compiler. Change something the compiler's own code generation depends on and you need an intermediate step that assumes neither version.
+
+The diagram below has one branch per case.
+
+```mermaid
+flowchart LR
+    q1{"Is what you changed<br/>used to compile<br/>anything?"}
+    q1 -->|"no: a stdlib leaf"| L1["bb refresh-stdlib"]
+    q1 -->|yes| q2{"Does the compiler's<br/>own emission<br/>depend on it?"}
+
+    q2 -->|"no: ordinary compiler<br/>or runtime change"| C1["bootstrap"]
+    C1 --> C2["bootstrap<br/>the fixpoint"]
+
+    q2 -->|"yes: a baked value"| H1["bootstrap<br/>with sparse-case"]
+    H1 --> H2["bootstrap<br/>the fixpoint"]
+
+    q2 -->|"yes: a signature the<br/>committed DLLs call"| S1
+
+    subgraph r1["round 1: bridge"]
+        direction LR
+        S1["bootstrap"] --> S2["bootstrap<br/>the fixpoint"]
+    end
+
+    subgraph r2["round 2: clean"]
+        direction LR
+        S3["bootstrap"] --> S4["bootstrap<br/>the fixpoint"]
+    end
+
+    S2 --> S3
+```
+
+If you are not sure which branch your edit is on:
+
+| What you edited | Branch |
+|---|---|
+| a stdlib source among the 25 leaves | leaf |
+| `clojure.string`, `clojure.set` or `clojure.walk` | leaf, unless the compiler calls the behaviour you changed |
+| a compiler `.clj`, or a C# runtime `.cs` | ordinary |
+| a long-stale DLL you are regenerating | ordinary |
+| how the runtime computes a value the compiler bakes, such as `hasheq` | baked value, and refresh the bootstrap set **and** the stdlib set |
+| a runtime constructor or method signature | two rounds |
+
+### A stdlib edit: one pass
+
+25 of the 28 namespaces `bb refresh-stdlib` owns are **leaves**. They run, and nothing is ever compiled with them, so there is no circularity to converge. Recompile, deploy, done.
+
+The other three, `clojure.string`, `clojure.set` and `clojure.walk`, are in `build.clj`'s list as well, because the compiler requires them. That changes nothing about the DLL: `bb refresh-stdlib` writes it, and no `magic.*` DLL has to be re-emitted because it moved. None of the three defines a macro or an inline, and `*direct-linking*` is off for the bootstrap, so every call the compiler makes into them resolves through a Var at load time.
+
+What can put you on the two-pass branch is the behaviour you changed, not the file it lived in. The compiler calls these three while it compiles, so if you touch something it relies on, its own output moves too and you are in the ordinary case below. A `bb check-drift` after a fresh `bb build` tells you which happened.
+
+One pass on the stdlib set is enough even for a baked-value change. A `case` jump table is built by `magic.core/case-compiler` calling `Util/hasheq` at compile time, and read by the compiled code calling the same `Util/hasheq` at run time, both out of the one committed `Clojure.dll`. Table and lookup come from the same function, so they cannot disagree.
+
+### A compiler or runtime change: two passes
+
+The first pass still runs the previous compiler, and each namespace macroexpands against its dependencies as the previous run left them, so it always carries old state. Only the second pass, compiled entirely against first-pass output, is the fixpoint. The committed set is always the fixpoint.
+
+| Pass | Compiler used | What it proves |
+|---|---|---|
+| 1 | the old committed DLLs | the change compiles at all |
+| 2 | pass 1's output | the fix survives being compiled by itself, so it is the fixpoint |
+
+### A long-stale DLL: two passes
+
+Same reason, arrived at from the other direction: pass 1 macroexpands against the stale state you are trying to replace. When `core_clr` was finally re-emitted, pass 1 also changed `clojure.core.clj.dll`, because the parent's `(load "core_clr")` picked up the edited source mid-unit and consumed different gensyms. Pass 2 loads the fresh DLL and settles.
+
+### A baked-value change: two passes, the first with sparse-case
+
+Most of what a `.clj.dll` references resolves at run time against the loaded `Clojure.dll`, direct linking included, which is a calling convention and not inlining. So a runtime method-body fix is an ordinary change. The exceptions are the values the compiler computes and bakes into its output at compile time: a `case` form becomes a jump table keyed on `Util/hasheq` results, and a `defrecord` bakes its type hash.
+
+Change how the runtime computes a baked value and the ordinary two passes cannot work: the committed compiler's own `case` dispatch is keyed on values the new runtime no longer produces, so it cannot be trusted to compile its own replacement. The way through is a first pass that bakes no such value at all. For hashes that is the `sparse-case` spell, which compiles `case` as a chain of `if` forms.
+
+```mermaid
+flowchart TD
+    p1["Pass 1: bb bootstrap :spells sparse-case<br/>old runtime, case as if-chains"]
+    cs["change the hashing in C#35;,<br/>rebuild Clojure.dll"]
+    p2["Pass 2: bb bootstrap<br/>jump tables, new hash, the fixpoint"]
+    rs["bb refresh-stdlib<br/>the other 28, one pass"]
+
+    p1 -->|"the committed compiler no longer<br/>assumes any hash"| cs
+    cs --> p2
+    p2 --> rs
+```
+
+Pass 2 is the fixpoint. The sparse-case compiler is built from the same compiler sources, so what it emits is what the final compiler emits, only its own `case` dispatch differs. A sparse-case round trip on an unchanged tree reproduces the committed bytes exactly.
+
+The last box has its own history. `bc629a67` changed the `hasheq` of every qualified keyword, and the companion refresh one minute later (`1b898f5d`) regenerated only the bootstrap 48; `bb refresh-stdlib` was not run. The other 25 kept their old-hash tables. `clojure.spec.alpha` was one of them, so `s/cat`, `s/*` and `s/alt` began throwing `No matching clause: :clojure.spec.alpha/pcat` at run time with nothing failing at build time. The compiler was fine and spec was fine. One committed binary was three hours out of date.
+
+**The rule:** a baked-value change is not done until both the bootstrap set and the stdlib set are refreshed. `bb check-drift` runs `refresh-stdlib` itself for exactly this reason.
+
+The same reasoning explains a pin that otherwise looks like an oversight: `AssemblyVersion` stays at `1.0.0.0` in `Directory.Build.props` rather than following `version.edn`, because every emitted `.clj.dll` bakes it into its assembly references and tying it to the release version would invalidate all 73 on every release.
+
+### A runtime signature change: bridge, then clean
+
+The committed `.clj.dll` reference runtime constructors and methods by exact signature, with a `newobj` against one specific constructor. Change that signature in `Clojure.dll` and the committed DLL fails to load with `MissingMethodException`, so `nos` cannot start, so it cannot regenerate the DLL that would have fixed it. Source compatibility and binary compatibility are independent here.
+
+This is the long branch. Each **round** takes the ordinary two passes, and the first must be finished before the second starts.
+
+```mermaid
+flowchart TD
+    subgraph p1["Round 1: bridge"]
+        a["add the new signature in C#35;,<br/>keeping the old one alive"]
+        b["move the Clojure source<br/>onto the new signature"]
+        c["rebuild runtime, re-bootstrap twice, deploy"]
+        a --> b --> c
+    end
+
+    subgraph p2["Round 2: clean"]
+        d["remove the old signature"]
+        e["rebuild runtime, re-bootstrap twice, deploy"]
+        d --> e
+    end
+
+    c -->|"the committed DLLs now reference<br/>only the new signature"| d
+    e --> done["a fresh checkout needs neither round"]
+```
+
+**The rule:** the two rounds land in history separately, bridge first. Each tree state stays buildable, so `git bisect` keeps working.
+
+## What else goes wrong
+
+Three traps that have nothing to do with pass counts.
+
+### A committed DLL must not be older than its source
+
+The loader picks between `clojure/set.clj` and `clojure.set.clj.dll` by which is newer, and git stores no mtimes, so after a clone the winner is luck. Every build task therefore stamps the committed DLLs before compiling anything, marking each DLL newer than its source unless `dll-sources.edn` says the source really changed. A run without the stamp corrupts nothing, but it recompiles dependencies from source, so it is no longer compiling against the committed set and DLLs written later in the run can move even though their own source did not.
+
+**The rule:** never a raw `dotnet build` after a fresh clone, because it skips the stamping step. The loader's decision tree, the stamping diagram and `MAGIC_DEBUG_LOAD=1` are in [deterministic compilation](./deterministic-compilation.md).
+
+### A Unity player build rewrites Export/ in place
+
+After a Unity player build, the DLLs in `Export/` are no longer the bytes the compiler wrote.
+
+The pre-build hook hands each assembly to Mono.Cecil ([Unity integration](./unity-integration.md) covers why), so those files come out as Cecil output rather than compiler output. It happens under both scripting backends, and the bytes differ even when no instruction changed. A Unity run can also flip the exec bit, so compare mode as well as bytes.
+
+To get back to a clean state, restore the directory from HEAD (`git checkout -- magic-unity/Runtime/Infrastructure/Export/`) or regenerate it with `bb refresh-stdlib` or `bb build`. `magic-unity-dual` holds a Unity-untouched copy if you need one.
+
+**The rule:** never commit `Export/` straight after a player build. And when a C# runtime fix means `Export/Clojure.dll` genuinely has to be committed, mind the order. `bb check-drift` restores `Clojure.dll` and `Magic.Runtime.dll` from HEAD, because both embed a `git describe` `SourceRevisionId` no rebuild can reproduce. So run `bb check-drift` **first**, then `dotnet build -t:MagicUnity` and `bb gen-unity-dual`, then commit. The other order looks clean and ships the old DLL.
+
+### A mono crash during assembly save
+
+Mono sometimes segfaults inside `AssemblyBuilder.Save` while writing `clojure.core.clj.dll`, the largest assembly and the last one built, and the process exits 134. It is sporadic and every occurrence has been clean on retry. The crash lands before the deploy step and never touches the committed DLLs, so nothing corrupt can ship from it. Retry the pass.
+
+## Where it came from
+
+The process above did not arrive in one piece. Each rule was added when something showed it was needed, and the timeline is that order.
+
+```mermaid
+timeline
+    title Ten years of the bootstrap
+    Jun 2016 : nostrand commits ClojureCLR's 4.7 MB Clojure.dll and compiles its Clojure at startup
+    Oct 2020 : the compiler-free fork lands with 71 .clj.dll beside it : sparse-case arrives 9 days later, so a hashing change stays bootstrappable
+    Nov 2022 : the bootstrap drives magic.api directly, ending a double compilation : the hashing fix lands through the sparse-case pass
+    May 2026 : bb refresh-stdlib covers the stdlib the bootstrap chain never touched
+    Jul 2026 : v0.10.0 makes the bytes deterministic, so the committed bytes become the check : (load ...) sub-files finally re-emit
+```
+
+From June 2016 `nostrand` committed exactly one binary: ClojureCLR's full `Clojure.dll`, 4.7 MB at the time. `Main` called `RT.load("clojure/core")`, and the DLR compiler inside that DLL read the `.clj` sources at startup. Requiring `magic.api` compiled MAGIC on the spot, every run.
+
+That changed in one commit, `ecddba98` (2020-10-12), titled "Start work on MAGIC Nostrand bootstrap", with the body "Working but not 100% reproducible yet". `Clojure.dll` drops from 5,967,360 bytes to 559,616, the compiler-free fork replacing the full runtime, and 71 `.clj.dll` appear next to it. `RT.load` gives way to the loop that still runs today. Eleven days later `References/` became `references/` and nostrand's own 8 `.clj.dll` were dropped, since its CLI and task code is recompiled into memory at every startup.
+
+The first hazard showed up nine days in, when `sparse-case` was added to handle hash values that "break across runtimes". Two years later the contract work that fixed hashing for real used exactly that escape hatch. The same stretch replaced `clojure.core/compile` with the MAGIC API in `build.clj` (`903ae224`), ending a double compilation, and gave `build.clj` the explicit ordered list it still has.
+
+The remaining changes all came from a committed binary going stale unnoticed. In May 2026 a `pprint` source fix went in with no committed DLL behind it, so whether the fix took effect came down to the mtimes a given clone happened to get. That exposed the real gap: the bootstrap chain ends at `clojure.core` and never touched most of the stdlib, so a fix there could not be re-emitted by any build flow. `bb refresh-stdlib` closed it (`254e387b`), and that is why the 73 are owned by two tasks today rather than one.
+
+Two blind spots closed after that, and both are rules above. `case` jump tables meant a DLL could go stale from a C# runtime change its own source never mentions, which only a byte diff can see. And the seven `(load ...)` sub-files no flow re-emitted were still carrying their 2020 and 2022 bytes, which only became visible once a rebuild was expected to reproduce them.
+
+Each of those changes replaced a step a maintainer had to remember with a CI check that fails when it is missed.

--- a/docs/clr-dependency-files.md
+++ b/docs/clr-dependency-files.md
@@ -1,58 +1,170 @@
 # Declaring CLR dependencies
 
-A library often needs different deps on the JVM and the CLR, and `deps.edn` (plain EDN) has no reader conditionals to say so. `nos` supports two ways to carry the CLR-specific deps. [Which one to pick](#which-to-use) comes down to who else builds the library.
+There are three ways to declare the CLR dependencies of a library. This page covers all three, and how `nos` resolves what you write.
 
-## `deps-clr.edn`: a separate CLR deps file
+## `deps.edn` is not enough
 
-A self-contained file at the project root (its own `:paths`, `:deps`, `:aliases`). `nos` reads it in place of `deps.edn` when present, and so does [ClojureCLR](https://github.com/clojure/clojure-clr)'s `cljr` (`deps-clr.edn` first, else `deps.edn`; see [clr.core.cli](https://github.com/clojure/clr.core.cli)). The JVM `deps.edn` stays untouched. It is ClojureCLR's own convention, so a library that uses it lines up with the wider CLR community's tooling.
+The blocker is Maven. Neither `cljr` nor `nos` has a Maven procurer.
+
+A JVM `deps.edn` nearly always declares `org.clojure/clojure {:mvn/version ...}` in its root `:deps`, and most JVM libraries arrive as Maven artifacts.
+
+So we need another file to list the deps as git deps. Sometimes the CLR port lives in another repo, sometimes a JVM lib carries CLR support via reader conditionals, but all need to be fetched via git. The solution the ClojureCLR community went for is a dedicated `deps-clr.edn`. MAGIC now also supports it for consistency.
+
+MAGIC also has another way to specify the JVM-CLR mapping directly in `deps.edn` using a dedicated `:clr` alias.
+
+## The three setups
+
+Pick one. The table compares them, and the sections after it cover each in turn.
+
+| | none (`deps.edn` only) | `:clr` alias | `deps-clr.edn` |
+|---|---|---|---|
+| Read by | `nos` only | `nos` only | `nos` **and** `cljr` |
+| Shared deps | declared once | declared once | repeated in two files |
+| Drift risk | none | none | SHAs can fall out of sync |
+| CLR-only path for consumers | no | no | yes |
+| Best for | no dependency delta, `nos`-only | JVM-to-CLR lib swaps, `nos`-only | anything ClojureCLR may build |
+
+`nos` skips Maven coordinates instead of failing on them, so all three work with `nos`. Only `deps-clr.edn` also works with `cljr`.
+
+The first setup needs no file of its own. If every dependency you need on the CLR is a git or local coordinate that works on both runtimes, `deps.edn` alone is enough: `nos` resolves the git deps and skips any Maven coordinate it meets. A JVM-only test dependency declared under an alias as `:mvn/version` costs nothing, because the alias still contributes its `:extra-paths`.
+
+## Recommended: `deps-clr.edn`, the ClojureCLR convention
+
+This is the one we recommend, because it is the only setup `cljr` can build.
+
+It can feel a bit overkill, especially if you have almost no CLR-only deps, but it is what makes your library build and test with `cljr`, the ClojureCLR CLI (see [clr.core.cli](https://github.com/clojure/clr.core.cli)), and that is the community standard to prove a lib supports the CLR. `nos` has read it since MAGIC 0.9.0, so a library already ported the ClojureCLR way needs no MAGIC-specific setup at all.
+
+It is a self-contained file with its own `:paths`, `:deps`, and `:aliases`. Both `cljr` and `nos` read it in place of `deps.edn` when present, and the JVM tools never read it, so the JVM `deps.edn` stays untouched.
 
 ```clojure
 ;; deps-clr.edn
 {:paths ["src"]
- :deps  {org.clojure/test.check {:git/url "https://github.com/flybot-sg/clr.test.check"
-                                 :git/sha "..."}}
- :aliases {:test {:extra-paths ["test"]}}}
+ :deps  {io.github.robertluo/fun-map {:git/sha "..."}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {org.clojure/test.check         {:git/url "https://github.com/flybot-sg/clr.test.check"
+                                                       :git/sha "..."}
+                       io.github.dmiller/test-runner  {:git/tag "v0.5.3clr"
+                                                       :git/sha "ae91dd2727bbf70eb3a6d869a19953de3819dfbc"}}
+         :exec-fn     cognitect.test-runner.api/test
+         :exec-args   {:dirs ["test"]}}}}
 ```
 
-`nos` and `cljr` read one file or the other, never a merge, so it restates every coordinate shared by both runtimes.
+Those two dependencies are the two shapes a CLR dependency comes in. `fun-map` is one repository serving both runtimes: its sources are `.cljc` carrying `:clj`, `:cljs` and `:cljr` reader conditionals, so the CLR loads the same code the JVM does. `clr.test.check` is the other shape, a CLR-only fork of `test.check`.
 
-## A `:clr` alias in `deps.edn`
+That is also why only one names a `:git/url`: `io.github.robertluo` implies `https://github.com/robertluo/fun-map.git`. `nos` infers from the same hosts `cljr` does, GitHub, GitLab, Bitbucket, Beanstalk and Sourcehut. A fork under another owner has to say where it lives.
 
-One `deps.edn` with a `:clr` alias that adds or swaps CLR deps via `:extra-deps`/`:override-deps`, activated with `:nos/aliases [:clr]` (or per build/test run via `magic.edn`'s `:aliases`). `nos` skips Maven coords (a JVM-only dep in `:deps` never resolves), and `:override-deps` swaps a fork wherever the lib appears, transitive deps included. The alias states only the JVM-to-CLR delta, so shared coordinates are declared once. `cljr` does not read it.
+### The cost: coordinates restated in two files
+
+A runtime reads one file or the other, never a merge, so `deps-clr.edn` restates every coordinate shared with the JVM. That is its one cost: a git dep used by both runtimes has its SHA in two files, and bumping one while forgetting the other leaves both suites green while they test different code.
+
+### What `nos` ignores in a file written for `cljr`
+
+`nos` honors `:extra-paths`, `:extra-deps` and `:override-deps`. It ignores `:deps`, `:paths`, `:replace-deps`, `:replace-paths`, `:default-deps` and `:classpath-overrides`, which `cljr` honors, warning on stderr with the key named rather than quietly resolving something the file does not say. An undeclared alias warns too, as `tools.deps` does.
+
+### Why the `deps.edn` fallback is not enough for `cljr`
+
+`cljr` falls back to `deps.edn` when there is no `deps-clr.edn`, and the fallback itself works: a `deps.edn` holding only `:paths` and git coordinates resolves fine. What kills it is any `:mvn/version` coordinate in the resolved tree.
+
+```
+$ cljr -Spath
+Error building classpath. Coord of unknown type: #:mvn{:version "1.9.0"}
+```
+
+A real dual-runtime library nearly always has one somewhere in its tree, so the fallback fails in practice.
+
+## MAGIC-only: the `:clr` alias in `deps.edn`
+
+This is an alternative to `deps-clr.edn`.
+
+The alias keeps everything in one file, at the price of `cljr` never being able to build it.
+
+This is the setup MAGIC 0.4.0 shipped. You map each JVM library to its CLR replacement under `:override-deps`. Maven deps are ignored, so the project must use git or local deps only.
 
 ```clojure
 ;; deps.edn
 {:paths ["src"]
- :deps  {org.clojure/test.check {:mvn/version "1.1.1"}}
+ :deps  {org.clojure/clojure         {:mvn/version "1.10.0"}  ;; dropped: the runtime provides it
+         io.github.robertluo/fun-map {:git/sha "..."}} ;; use git deps so no need to add it in :clr
  :aliases
  {:clr  {:override-deps
          {org.clojure/test.check {:git/url "https://github.com/flybot-sg/clr.test.check"
                                   :git/sha "..."}}}
-  :test {:extra-paths ["test"]}}}
+  :test {:extra-paths ["test"]
+         :extra-deps  {org.clojure/test.check {:mvn/version "1.1.1"}}}}}
 ```
 
-## Which to use
+Only `test.check` needs an override, because only `test.check` lives somewhere else on the CLR. `fun-map`, a git coordinate both runtimes resolve, stays in the root `:deps` untouched, and the JVM never notices the alias exists.
 
-The deciding question: does anything other than `nos` build this library?
+`:override-deps` applies the replacement wherever the lib appears, transitive deps included, so shared coordinates stay declared once. `cljr` activates aliases too, but still chokes on the Maven coordinates around them, which is what makes this a `nos`-only setup.
 
-- **Public CLR library**: use `deps-clr.edn`. Its users build with stock ClojureCLR's `cljr`, which expects that file.
-- **Internal, `nos`-only library**: use a `:clr` alias. Nothing else reads the deps, so a separate file only adds cost.
+### A shipped path reaches the JVM too
 
-| | `deps-clr.edn` | `:clr` alias |
-|---|---|---|
-| Read by | `nos` **and** `cljr` | `nos` only |
-| Shared deps | repeated in two files | declared once |
-| Drift risk | SHAs can fall out of sync | none |
-| Best for | public CLR libraries | internal, `nos`-only libraries |
+The downside of using an alias shows up with CLR-only load paths, the kind [pre-compiled assembly loading](./native-assemblies.md) needs. You have to declare that path in the root `:paths` of `deps.edn`, which means it ships on the JVM too. That is only a problem if you also run the lib on the JVM.
 
-The main cost of `deps-clr.edn` is drift: a git dep used by both runtimes has its SHA in two files, so it is easy to bump one and forget the other. Default to a `:clr` alias while the library is internal, and switch when it goes public. The switch is a small mechanical edit.
+## Activating aliases, since `nos` takes no alias flag
 
-## How `nos` chooses
+An alias does nothing until something activates it, and that holds in both files: the `:test` alias of a `deps-clr.edn` and the `:clr` alias of a `deps.edn` are activated the same way. On the JVM the command line does it (`clj -M:clr`). The `nos` commands take no alias flags, so the project states its aliases in `magic.edn`, which the built-in `nos build` and `nos test` read:
 
-`deps-clr.edn` if present, else `deps.edn`, both at the project root and for every git or local dep it resolves, the same preference `cljr` applies. A dependency contributes the `:paths` and `:deps` of whichever file it ships, so a library can declare a CLR-only path in its `deps-clr.edn`, the directory of a precompiled assembly for instance, and consumers get it without that path reaching its JVM `deps.edn`.
+```clojure
+;; magic.edn
+{:build {:aliases [:clr]}
+ :test  {:aliases [:clr :test]}}
+```
 
-The `nos`-specific keys `:nos/aliases` and `:nos/submodule-paths` are read from whichever file `nos` uses, so move them into `deps-clr.edn` if you add one.
+`:nos/aliases` in the deps file predates `magic.edn` and covers what `magic.edn` does not: `nos repl` and hand-written task files, which activate it at boot. A library that only builds and tests can skip it. The full `magic.edn` surface is in [the `nos` CLI](./nos-cli.md).
 
-## See also
+## How `nos` resolves what you wrote
 
-[Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md) for the surrounding workflow.
+`nos` walks the dependency tree breadth-first, and the diagram below is what happens to each coordinate it meets.
+
+```mermaid
+flowchart TD
+    q["a coordinate from the queue"]
+    can{"a git coord with<br/>no resolvable url?"}
+    err["resolution throws"]
+    rp{"provided by<br/>the runtime?"}
+    seen{"already resolved?"}
+    nat{"git or local?"}
+    proc["clone into the cache,<br/>or use the local path"]
+    read["read its deps-clr.edn,<br/>else its deps.edn"]
+    add["queue its :deps,<br/>minus :exclusions"]
+    skip["skipped"]
+    keep["first sighting wins"]
+
+    q --> can
+    can -->|yes| err
+    can -->|no| rp
+    rp -->|yes| skip
+    rp -->|no| seen
+    seen -->|yes| keep
+    seen -->|no| nat
+    nat -->|"maven"| skip
+    nat -->|yes| proc --> read --> add
+    add --> q
+```
+
+**Which deps file.** `deps-clr.edn` if present, else `deps.edn`, at the root and for every resolved dep, the same preference `cljr` applies. A dep can therefore carry a CLR-only path in its own `deps-clr.edn`, a precompiled assembly's directory for instance, without it reaching its JVM `deps.edn`. `:nos/aliases` and `:nos/submodule-paths` come from whichever file wins.
+
+**A dep's source paths.** `:paths` on the coordinate, else the dep's own deps file, else `src`. Coord `:paths` is a `nos` addition; `cljr` ignores it and reads a `pom.xml`. It is how `magic-compiler` reaches `org.clojure/tools.analyzer`, a pom-only lib, with `:paths ["src/main/clojure"]`.
+
+**Git and local coordinates only.** Anything else, Maven in practice, is skipped, counted and named on stderr at the end. That is what lets a `:test` alias contribute its `:extra-paths` while its JVM-only tooling goes unresolved.
+
+**Three libs are dropped by name.** `org.clojure/clojure`, `org.clojure/spec.alpha` and `org.clojure/core.specs.alpha`: the runtime provides them, and the check runs before the coordinate type, so a git spelling does not bring them back. Nothing else is exempt, not even `clojure.tools.analyzer`, which `nos` ships compiled yet resolves normally.
+
+**Coordinates read as `tools.deps` reads them.** Legacy `:sha` and `:tag` fold into `:git/sha` and `:git/tag`, both spellings at once is an error, `:local/root` resolves against its deps file's directory, and `:deps/root` picks a subdirectory of the clone. A missing `:git/url` is inferred from the group for the five hosts above; any other host throws rather than silently building a short classpath.
+
+**Closest wins.** The sighting nearest the root is kept; later ones warn only on a real divergence, a short SHA and the full SHA it abbreviates counting as one commit. A coord's `:exclusions` drop those libs from everything below it.
+
+**Where clones land.** `$GITLIBS/nostrand` when `GITLIBS` is set, keeping CLR checkouts apart from JVM entries in a shared cache, else `~/.nostrand/gitlibs`.
+
+## Seeing what resolved: `nos print-basis`
+
+When a dep resolves to something you did not expect, print the basis.
+
+```bash
+nos print-basis            # base :deps only
+nos print-basis :clr :test # with aliases
+```
+
+It prints the paths and every lib with the SHA, tag or local root it settled on, compiling nothing. Cloning git deps into the cache is the one side effect.

--- a/docs/deterministic-compilation.md
+++ b/docs/deterministic-compilation.md
@@ -1,79 +1,200 @@
 # Deterministic compilation and the drift check
 
-This repo commits compiled binaries: the compiler is self-hosting, so `nostrand/references/*.clj.dll` ARE the compiler that compiles the next compiler.
-`magic-unity/Runtime/Infrastructure/Export/*.dll` is the prebuilt runtime the Unity package ships.
+MAGIC compiles deterministically since v0.10.0, with the last two nondeterminism holes closed in v0.11.0: the same sources and the same toolchain produce the same bytes, on any machine.
 
-Committed binaries can go **stale**: the checked-in bytes no longer match what a rebuild of the current sources would produce. This page explains how this happens, why we made compilation deterministic to catch it, and what `bb check-drift` actually checks.
+That is what makes the drift check simple. After a bootstrap reaches its fixpoint (two passes when the compiler changed, [the bootstrap](./bootstrap.md)), `git status` names exactly the committed DLLs a fix affected, and CI byte-diffs every one of them against a fresh rebuild. A committed DLL whose bytes no longer match that rebuild has **drifted**. Before the bytes were reproducible there was nothing to compare, so the check hashed sources instead, and a whole class of staleness got through.
 
-## The problem: a DLL can go stale without its source changing
+Two directories hold those committed binaries: `nostrand/references/`, the 73 `.clj.dll` that are the compiler and stdlib themselves, and `magic-unity/Runtime/Infrastructure/Export/`, the 37 stdlib `.clj.dll` plus the two C# runtime DLLs that Unity ships. What each holds and why is in [the bootstrap](./bootstrap.md#what-is-committed-and-why).
 
-The obvious staleness is easy to guard: someone edits `clojure/spec/alpha.clj` and forgets to recompile `clojure.spec.alpha.clj.dll`. Hashing the source file catches that, and that is what we used to do, with two SHA256 manifests.
+## A DLL can go stale without its source changing
 
-The staleness that actually bit us is the other kind. A change to the C# runtime altered `hasheq`, the hash function whose values the compiler bakes into the jump tables of every compiled `case` expression. Every committed DLL containing such a table was now wrong, yet not one `.clj` source had changed, so every source fingerprint stayed green. The bug only surfaced at runtime, as `No matching clause` deep inside spec, a long way from its cause.
+There are two kinds of staleness, and telling them apart is the whole design.
 
-The lesson: a compiled DLL is a function of much more than its own source. The diagram below shows everything that feeds the bytes.
+In the first, someone edits `clojure/spec/alpha.clj` and forgets to recompile `clojure.spec.alpha.clj.dll`. The source moved, so hashing the source finds it, which is what `dll-sources.edn` does.
 
-```mermaid
-flowchart LR
-    subgraph inputs["What the bytes depend on"]
-        src["Namespace .clj source"]
-        cmp["Compiler<br/>(magic.* .clj)"]
-        rt["C# runtime<br/>(Clojure.dll, Magic.Runtime.dll)"]
-        drv["Driver script<br/>(refresh.clj, build.clj)"]
-    end
-    inputs --> compile["MAGIC compile"]
-    compile --> dll["namespace.clj.dll<br/>committed bytes"]
-```
+The second never touches a `.clj`. A C# runtime change once altered `hasheq`, the hash function whose values the compiler bakes into the jump tables of every compiled `case` expression. Every committed DLL holding such a table had drifted, yet no `.clj` source had changed, so every source hash stayed green. No error, no stack trace, just `No matching clause` at runtime deep inside spec, a long way from its cause.
 
-A fingerprint of one input cannot guard an output that depends on four. The only fingerprint that covers them all is the output itself: the DLL bytes.
+A source hash cannot see that second kind, ever.
 
-## Deterministic compilation makes bytes comparable
+## What the bytes of one DLL depend on
 
-Byte-diffing compiled output is useless if the compiler emits different bytes on every run, and it used to. Two things varied:
-
-- **Emission order.** Members were emitted by iterating hash-keyed collections (the lifted Var cache fields, the override methods of `reify`/`proxy`/`deftype`, the `Magic.Function` interface set). CLR identity hashes vary per process, so member order, and every IL offset behind it, reshuffled between runs. All three sites now sort by a content-derived key.
-- **Assembly headers.** `Reflection.Emit` stamps a random **MVID** (a GUID identifying the module) and the current time in the PE header. After saving, we now zero the timestamp and rewrite the MVID as the SHA256 of the normalized file, so both derive from content.
-
-With that, compiling the same namespace against the same toolchain produces byte-identical DLLs, verified across all 73 committed reference DLLs. Determinism is what turns `git diff` into a staleness detector.
-
-## The drift check: rebuild, then diff
-
-`bb check-drift` regenerates everything that is generated and fails if any checked path differs from HEAD:
+A compiled DLL is a function of much more than its own source. The diagram takes `clojure.spec.alpha.clj.dll` and shows everything that feeds its bytes.
 
 ```mermaid
 flowchart TD
-    build["bb build<br/>(fresh full build)"] --> drift["bb check-drift"]
-    drift --> regen["regen callsite .g.cs"]
-    drift --> stdlib["recompile + redeploy<br/>stdlib .clj.dll"]
-    drift --> dual["sync UPM version,<br/>regen magic-unity-dual"]
-    regen --> diff{"git status over<br/>committed dirs"}
-    stdlib --> diff
-    dual --> diff
-    diff -->|clean| green["green: everything current"]
-    diff -->|differs| red["red: stale files listed,<br/>refreshed versions in the tree"]
+    src["Its own source<br/>magic-compiler/src/stdlib/<br/>clojure/spec/alpha.clj"]
+    cmp["Compiler and emitter<br/>magic-compiler/src/magic/<br/>mage/src/mage/core.clj<br/>tools.analyzer sha in deps.edn"]
+    rt["C# runtime<br/>clojure-runtime/Clojure/<br/>magic-runtime/Magic.Runtime/"]
+    drv["Build scripts<br/>magic-compiler/build.clj<br/>magic-compiler/refresh.clj"]
+    src -->|"the forms<br/>being compiled"| compile["MAGIC compile"]
+    cmp -->|"does the<br/>transforming"| compile
+    rt -->|"the compiler runs on it,<br/>so values it computes get<br/>baked in as constants<br/>(hasheq case tables)"| compile
+    drv -->|"sets the flags and<br/>the compile order"| compile
+    compile --> dll["clojure.spec.alpha.clj.dll<br/>committed to both directories above"]
 ```
 
-The stdlib DLLs are recompiled by the check itself. The bootstrap set (`clojure.core`, `magic.*`, `mage`) is redeployed by the fresh `bb build` that precedes the check, both in CI and in the pre-PR sequence from [CONTRIBUTING.md](../CONTRIBUTING.md), so its drift shows up in the same diff. Run the check without a fresh build and you still cover callsites, stdlib, version, and the dual variant; you just lose the bootstrap coverage.
+## Making the bytes reproducible
 
-Byte-identity also holds across machines: a Linux container (mono 6.12) reproduces every committed DLL byte-for-byte from a macOS checkout (mono 6.14) at a different filesystem path. Three mechanisms originally tied the bytes to the environment, each found by diffing the IL of the same namespace compiled on both systems, and each is now fixed in the compiler:
+Byte-diffing compiled output is useless if the compiler emits different bytes on every run, and it used to.
 
-- **Culture-sensitive sorting.** The emission sorts compared strings with the CLR's `String.CompareTo`, which follows the OS collation rules. They now compare raw UTF-16 units (`String/CompareOrdinal`), the same order the JVM uses.
-- **Absolute source paths.** Every `def` bakes its `:file` metadata into the DLL, and MAGIC recorded the absolute path, so the checkout directory changed the bytes. `*file*` is now bound to the load-relative path (`clojure/zip.clj`), which is also what JVM Clojure records.
-- **Global gensym state.** Auto-gensym numbers came from a process-global counter, so they carried whatever nostrand's boot and deps resolution had consumed, which varies by platform. The counter is reset at each file-writing compilation unit, making emitted names a function of the unit alone. This also means editing a driver script like `refresh.clj` no longer renumbers unrelated DLLs.
+Making it deterministic took four changes:
 
-Two operational rules keep cross-machine identity true:
+### 1. Hash-order iteration
 
-- **Committed DLLs must be mtime-newer than their sources.** `clojure.core/load-one` picks source vs DLL by mtime, and a fresh checkout leaves them ambiguous; loading a dependency from source consumes different gensyms and changes downstream bytes. `bb build`, `bb bootstrap`, and `bb refresh-stdlib` touch the committed DLLs first, so use them rather than raw `dotnet build` after a fresh clone.
-- **Rebuild twice after changing the compiler.** The compiler is self-hosting: the first pass still runs the previous compiler, so only the second pass's output is the fixpoint. The committed set is always the fixpoint.
+The same `reify`, compiled twice, used to emit its methods in two different orders:
 
-CI runs the full byte-diff (`bb build` then `bb check-drift`). For an environment whose toolchain fails to reproduce the bytes, `bb check-drift skip-dlls` is the fallback: it restores the committed DLLs and checks `magic-compiler/dll-sources.edn` instead, the recorded SHA256 of each `.clj` source behind a committed DLL. That still catches a source edited without its DLL refreshed, but is blind to compiler and C# runtime triggers. The byte-diff is what closes that blind spot: re-running the hasheq scenario from the top of this page now flags 11 stale DLLs, `clojure.spec.alpha` among them.
+```clojure
+(reify System.IDisposable (Dispose [_] ...)
+       Object             (ToString [_] ...))
+```
 
-When the check goes red, the working tree already holds the refreshed files. If the drift is expected, commit them as the paired refresh commit (`chore(bootstrap): refresh <name> DLL for <reason>`); if it is not, investigate before reverting, because an unexplained byte change means one of the four inputs above changed behavior.
+```text
+the generated type before the fix, as monodis showed it:
 
-## The edges worth knowing
+run 1:                            run 2:
+.method public Dispose  ...       .method public ToString ...
+.method public ToString ...       .method public Dispose  ...
+```
 
-Three behaviors follow from "bytes are the fingerprint" and surprise people once each:
+Same source, two byte-different DLLs: member order moves every method body, and every IL offset behind it moves too.
 
-- **`Export/Clojure.dll` and `Export/Magic.Runtime.dll` are never byte-diffed.** Their csproj stamps a `SourceRevisionId` from `git describe` into the assembly, so their bytes change with every commit by design and no rebuild can reproduce the committed ones. `check-drift` restores these two from HEAD; maintainers refresh them deliberately.
-- **Editing a driver script renumbers gensyms downstream.** Clojure's gensym counter is process-global, and loading `refresh.clj` or `build.clj` consumes gensyms before any namespace compiles. Edit the driver and the next rebuild re-emits the DLLs compiled after it with shifted `G__N` names. The churn is benign, assembly-internal renames only, and the answer is the same paired refresh commit.
-- **After changing runtime semantics, refresh twice.** A namespace macroexpands against its dependencies as loaded from the previous run's DLLs, so the first refresh after a semantic runtime change can still carry old expansion state. The second pass, compiled entirely against first-pass output, is the fixpoint. This is the same reason changing hashing semantics is a two-pass protocol: `bb bootstrap :spells '[magic.spells.sparse-case/sparse-case]'`, then `bb bootstrap` again.
+The compiler collects those override methods in a map keyed by `MethodInfo`, and a `MethodInfo` is a host object with no value to hash: it hashes by identity, from a handle the CLR assigns per process, so a map of them iterates in a different order in every process. The same goes for `Type` and `Var` objects. Clojure's value hashing (`hasheq`) plays no part in this; only host objects hash that way.
+
+Five sites read collections that way, and each now sorts by a key built from the content:
+
+| Site | What hash order used to decide | The sort now |
+|---|---|---|
+| the lifted Var cache fields | field order on the generated class | `(sort-by var-name u/ordinal-str-compare)` in `magic/spells/lift_vars.clj` |
+| the override methods of `reify`, `proxy` and `deftype` | member order, and every IL offset behind it | `(sort-by (comp stable-method-key key) u/ordinal-str-compare)` in `magic/core.clj` |
+| the `Magic.Function` interface set | interface order on the fn type | `(sort-by str u/ordinal-str-compare)` in `magic/core.clj` |
+| `fresh-type`, which reuses generated types | which type gets reused | `(sort-by #(.Name %) ...)` in `magic/analyzer/generated_types.clj` |
+| loop binding-type inference | which type a binding gets | `(sort-by str ...)` in `magic/analyzer/loop_bindings.clj` |
+
+The Var cache fields come from the `lift-vars` spell: each referenced Var becomes a static field (`clojure_core$inc`), so a body loads a field instead of resolving the Var. For override methods the sort key is the whole signature, with the metadata token only as a tiebreaker:
+
+```clojure
+;; magic/core.clj
+(defn stable-method-key
+  "Signature string totally ordering override methods for deterministic emission
+   (MethodInfo maps iterate in per-run handle-hash order). Token breaks any tie."
+  [method]
+  (str (.DeclaringType method) "|"
+       (.Name method) "|"
+       (string/join "," (map #(str (.ParameterType %)) (.GetParameters method))) "|"
+       (.ReturnType method) "|"
+       (.MetadataToken method)))
+```
+
+Every one of those sorts compares ordinally, never with `compare`: `compare` on strings calls `String.CompareTo`, which follows the OS collation rules, so the same sort could order differently on another machine.
+
+```clojure
+;; magic/util.clj
+(defn ordinal-str-compare
+  "Compare by raw UTF-16 units: CLR String.CompareTo (what compare uses)
+   is culture-sensitive, so sorting with it varies across machines."
+  [^String a ^String b]
+  (String/CompareOrdinal a b))
+```
+
+### 2. Absolute paths in `:file` metadata
+
+Every `def` bakes its source's `:file` path into metadata. It used to be the absolute path, so the checkout directory changed the bytes. It is now the load-relative path, e.g. `clojure/zip.clj` instead of `/home/me/magic/magic-compiler/src/stdlib/clojure/zip.clj`, as on JVM Clojure.
+
+### 3. The gensym counter
+
+Gensym and generated-type numbers come from counters that used to be global to the process, and everything `nos` does before compiling your file consumes them: booting compiles nostrand's own Clojure in memory, resolving dependencies runs more. Any change to that prelude shifts every number your file bakes. Every anonymous fn becomes a generated type, and each generated type takes one tick of the type-name counter, so adding a single `#()` to `nostrand/core.clj` once renumbered every committed stdlib DLL, the only content difference being `__49` becoming `__50` in each:
+
+```mermaid
+%% mermaid lays disconnected subgraphs out in reverse declaration order,
+%% so "after" is declared first to render "before" on the left
+flowchart TD
+    subgraph after["after"]
+        direction TB
+        a1["one fn added early:<br/>boot code or an early namespace"] --> a2["every DLL starts its numbering<br/>from the same reset value"]
+        a2 --> a3["only DLLs whose own<br/>source changed differ"]
+    end
+    subgraph before["before"]
+        direction TB
+        b1["one fn added early:<br/>boot code or an early namespace"] --> b2["the shared counter is one<br/>ahead from there on"]
+        b2 --> b3["every DLL compiled after<br/>changes: __49 becomes __50"]
+    end
+```
+
+The reset happens only for file-writing compiles, so emitted names are a function of the namespace and toolchain alone, and REPL evals keep globally unique gensyms.
+
+### 4. Assembly headers: MVID and timestamp
+
+`Reflection.Emit` stamps two things into the [PE](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format) header that say nothing about the code. We rewrite both once the file is on disk:
+
+| PE header field | What `Reflection.Emit` writes | What `normalize-assembly!` writes instead |
+|---|---|---|
+| **MVID**, the GUID identifying the module | a fresh random GUID on every run | the SHA256 of the file, shaped into a well-formed GUID |
+| Timestamp | the time of the build | zero |
+
+The order matters. Both fields are zeroed first, then the file is hashed, then the hash goes into the MVID slot. Hashing only after they are cleared is what makes the result reproducible, since a file cannot contain the hash of itself.
+
+## The mtime rule: loading the committed set
+
+Determinism makes a rebuild reproducible only when it compiles against the committed set, and after a clone that is not a given.
+
+For each `require` the loader picks between the source and its one paired assembly, newest [mtime](https://en.wikipedia.org/wiki/MAC_times) (the filesystem's last-modified timestamp) wins. The pairing follows the extension, so `clojure/set.clj` pairs with `clojure.set.clj.dll` and `my/ns.cljc` with `my.ns.cljc.dll`. MAGIC inherits the rule from JVM Clojure, where AOT output is local build junk under `classes/` and the timestamps really do mean "the source moved on". Ours travels through git, which stores no mtimes, so after a clone every file carries the time git wrote it. The build tasks put a meaningful mtime back:
+
+```mermaid
+flowchart TD
+    touch["bb build, bb bootstrap, bb refresh-stdlib<br/>stamp every committed DLL first"] --> hash{"Source still hashes to<br/>dll-sources.edn?"}
+    hash -->|yes| newer["DLL mtime = source + 1s"]
+    hash -->|no| older["DLL mtime = source - 1s"]
+    newer --> cmp{"On require, is the DLL<br/>at least as new as the source?"}
+    older --> cmp
+    cmp -->|yes| loaddll["Load clojure.set.clj.dll,<br/>the committed bytes"]
+    cmp -->|no| recomp["Compile clojure/set.clj again<br/>instead of using the committed DLL"]
+```
+
+Recompiling is the branch to avoid. It is slower than loading, and the run is no longer compiling against the committed set, so DLLs written later in the same run can drift even though their own source did not change. That is why a raw `dotnet build` after a fresh clone is the thing to avoid. Set `MAGIC_DEBUG_LOAD=1` to watch which file the loader picks, with both timestamps.
+
+## The drift check: rebuild, then diff
+
+`bb check-drift` regenerates every committed output, then fails if any of them differs from HEAD.
+
+The first version could not compare bytes that moved every run, so it hashed the sources instead, across two separate manifests. That is the design the `hasheq` bug walked straight through. Determinism collapsed the two rules into one, and the two manifests became the single `dll-sources.edn`, whose job today is stamping the mtimes above.
+
+### What `bb check-drift` regenerates, and what it only restores
+
+```mermaid
+flowchart TD
+    build["bb build<br/>fresh full build: regenerates the<br/>45 bootstrap-owned .clj.dll"] --> regen
+    subgraph cd["bb check-drift"]
+        regen["regen-callsites<br/>the 5 Mustache templates into<br/>the 97 .g.cs in Magic.Runtime/Generated/"]
+        regen --> stdlib["refresh-stdlib<br/>recompile 28 stdlib .clj.dll into<br/>both dirs, re-record dll-sources.edn"]
+        stdlib --> upm["sync-upm-version, gen-unity-dual<br/>version.edn to package.json,<br/>magic-unity-dual/"]
+        upm --> diff["git status over the checked paths:<br/>any difference from HEAD fails,<br/>naming what drifted"]
+    end
+```
+
+The callsite templates are the easy case: five Mustache templates, one per callsite shape, rendered once per arity into 97 committed `.g.cs` that compile into `Magic.Runtime.dll`. Plain text, identical every run.
+
+`package.json` is checked because the monorepo keeps one version, in `version.edn`, which `Directory.Build.props` feeds to every C# project automatically. The Unity package's `package.json` is plain JSON that MSBuild cannot reach, so a task copies the version across and the check catches a `version.edn` bump that forgot it.
+
+`refresh-stdlib` rewrites 28 of the 73 committed DLLs; the rest belong to `bb bootstrap` ([which task owns what](./bootstrap.md#which-task-to-run)). That is why the check wants a fresh `bb build` in front of it: CI runs that sequence, and so does the pre-PR checklist in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+A refresh that fails to compile anything deploys nothing and exits non-zero, so a half-written set of committed DLLs is not a state you can reach. And a red run already holds its remedy: the regeneration happens before the diff, so the refreshed files are sitting in the working tree, ready for the paired refresh commit ([CONTRIBUTING.md](../CONTRIBUTING.md)).
+
+## The one exception: the two C# DLLs in `Export/`
+
+`Export/Clojure.dll` and `Export/Magic.Runtime.dll` are built by csproj, and their csproj stamps a `SourceRevisionId` from `git describe` into the assembly. Their bytes change with every commit by design, and no rebuild reproduces the committed ones. `check-drift` restores those two from HEAD, and maintainers refresh them deliberately.
+
+## Where it came from
+
+Staleness has been handled three ways over the years: by convention, where a DLL import named the upstream commit it was built from; by CI, publishing built artifacts so nobody had to rely on their local tree; and by a check inside the repo, first over sources and now over bytes.
+
+```mermaid
+timeline
+    title Guarding the committed DLLs
+    Oct 2020 : the first committed .clj.dll set : each import names the upstream commit it was built from
+    Dec 2022 : a CI action starts publishing built artifacts, so a consumer need not rely on its local tree
+    May 2026 : the first two drift checks : one hashes the stdlib sources, one regenerates the callsite templates
+    Jun 2026 : source hashing extended to the bootstrap set
+    Jul 2026 v0.10.0 : the bytes become reproducible, so the check becomes a byte diff : seven DLLs no flow re-emitted surface at once
+    Jul 2026 v0.11.0 : the last two hash-order holes close, the analyzer sites above
+    Aug 2026 : the last stdlib DLLs come under the byte diff, and a failed refresh stops exiting 0
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,110 @@
+# Development
+
+`bb.edn` is the task runner. Every task names the edit it belongs to, and this page is what each one does. `bb tasks` prints the short version.
+
+## Start from the edit
+
+Find the file you touched, run the task on its row, then `bb test`.
+
+| You changed | Run | Runs |
+|---|---|---|
+| any C# in `clojure-runtime/`, `magic-runtime/` or `nostrand/` | `bb build-runtime` | one `dotnet build` |
+| a callsite `.mustache` template | `bb dev-callsites` | `regen-callsites` → `build-runtime` |
+| `magic-compiler/src/stdlib/**/*.clj`, outside the `clojure.core` family | `bb refresh-stdlib` | one compile pass over the stdlib |
+| `magic-compiler/src/magic/**/*.clj`, `mage/src/`, or the `clojure.core` family | `bb dev-compiler` | `bootstrap` → `bootstrap` |
+| a fresh clone | `bb build` | clean, then all of the above |
+
+A compiler change needs two bootstrap passes, hence the convenience task `bb dev-compiler`. For more information check [the bootstrap](./bootstrap.md), which also covers why the `clojure.core` family belongs to the bootstrap instead of `refresh-stdlib`, and which changes need more than two passes.
+
+## Building
+
+**`bb build-runtime`** builds `nostrand/NostrandMain.csproj` in Release. `clojure-runtime` and `magic-runtime` come along through `ProjectReference`, so it covers the C# the host and the compiled DLLs run on.
+
+**`bb bootstrap`** is one pass of the compiler's own rebuild: compile with the compiler currently in `references/`, deploy over it, re-record `dll-sources.edn`. Extra arguments reach `nos`, which is how a spell is enabled for a pass:
+
+```bash
+bb bootstrap :spells '[magic.spells.sparse-case/sparse-case]'
+```
+
+**`bb refresh-stdlib`** recompiles every committed stdlib namespace outside the `clojure.core` family into `nostrand/references/`, the built host, and the Unity package's `Export/`.
+
+**`bb build`** is the fresh-clone path and the one CI runs. It cleans first, so the bootstrap is always redone from scratch. **`bb clean`** removes the `bin/` directories and `magic-compiler/bootstrap/`.
+
+`bb build`, `bb bootstrap` and `bb refresh-stdlib` stamp the committed DLL mtimes before compiling, which is what decides whether a namespace loads from its DLL or recompiles from source. That is why a raw `dotnet build` is not a substitute ([deterministic compilation](./deterministic-compilation.md)).
+
+## Regenerating what is committed
+
+- **`bb regen-callsites`** writes the 97 `.g.cs` under `magic-runtime/Magic.Runtime/Generated/` from five `.mustache` templates. A template edit is only real once this has run.
+- **`bb sync-upm-version`** copies the version from `version.edn` into `magic-unity/package.json`.
+- **`bb gen-unity-dual`** rebuilds `magic-unity-dual/` from `magic-unity/`, constraining the 37 runtime `.clj.dll.meta` to `!UNITY_EDITOR`. Run it after any `magic-unity` change.
+- **`bb check-drift`** runs all three plus `refresh-stdlib`, then fails if any checked path differs from HEAD. Run it after a fresh `bb build`, as CI does. What it byte-diffs and what it only restores are in [deterministic compilation](./deterministic-compilation.md).
+
+## Testing
+
+```bash
+bb test                                    # the whole suite
+bb test magic.test.fn magic.test.reify     # just these namespaces
+```
+
+`nos test` turns `*direct-linking*` and `*strongly-typed-invokes*` off so `with-redefs` can still rebind calls ([what they change](./nos-cli.md#compiler-flags)). Only `magic.test.fn` binds direct linking back on, for named-fn self-reference, and nothing covers strongly-typed invokes, so build a real consumer project after a compiler change. IL2CPP-only failures need [magic-unity-smoke](../unity-examples/magic-unity-smoke), and editor coexistence needs `bb coexist-noise`.
+
+## Inspecting a form
+
+**`bb pipeline`** walks a form through the compiler and stops before running it: form → macroexpand → AST → symbolic IL.
+
+```bash
+bb pipeline '(let [x 1] (+ x 1))'
+bb pipeline '(let [x 1] x)' :sections '#{:ast :il}'           # stdout only, no files
+bb pipeline '(.Length "hi")' :sections '#{:il-edn}' :out /tmp # just the flat IL
+```
+
+`TYPES` is the section to read when diagnosing intrinsic rewrites, static versus dynamic call-site selection, or numeric promotion. EDN dumps land in `magic-compiler/target/`, `pipeline-il.edn` being the one you usually want. An argument that is not readable EDN passes through as a symbol, so write `(deref a)` rather than `@a`.
+
+**`bb prepl-server`** and **`bb prepl-eval`** answer the other question: pipeline shows how a form compiles, a prepl shows what it does. The server is MAGIC Clojure (`clojure.core.server/io-prepl`) on a warm runtime, the client is plain babashka, so each eval is fast.
+
+```bash
+bb prepl-server                   # blocks; 127.0.0.1:5555, override: bb prepl-server 5560
+
+# from another shell
+bb prepl-eval '(+ 1 2)'           #=> {:tag :ret, :val "3", :ns "user", :ms 1.3, ...}
+bb prepl-eval '(def answer 42)'   # global defs persist across calls
+bb prepl-eval '(/ 1 0)'           #=> {:tag :ret, :exception true, :val "{... :cause \"Divide by zero\"}"}
+```
+
+Replies are tagged `:ret` (with `:ms` timing), `:out` and `:err`, and `:tap`. The form goes straight to the socket without `nos` argument parsing, so `@a` works here. Mono only, since a prepl evaluates at run time.
+
+**`bb repl`** is the Nostrand CLI REPL in `magic-compiler/`. For iterating on compiler `.clj` files, `(require '... :reload)` is seconds where two bootstrap passes are minutes.
+
+## The coexistence repro
+
+```bash
+bb coexist-noise             # dual variant, expect 0 narration lines
+bb coexist-noise magic-only  # default variant, expect 37
+```
+
+Drives [`magic-unity-coexist`](../unity-examples/magic-unity-coexist) headless and prints the narration count with a `:status`. Read that status: the task exits 0 either way, so a regression will not fail your shell. Needs Unity `2022.3.62f3` and no GUI editor holding the project, otherwise batchmode exits 134.
+
+## MSBuild targets underneath
+
+`Magic.csproj` holds the targets the `bb` tasks call. Reach for one directly only for the narrow job it names, remembering that a raw `dotnet build` skips the mtime stamping.
+
+| Target | What it does |
+|---|---|
+| `dotnet build -t:Nostrand` | build the task runner only |
+| `dotnet build -t:Magic` | bootstrap the compiler into `magic-compiler/bootstrap/` (needs mono), or nothing if that directory exists |
+| `dotnet build -t:Bootstrap` | copy those DLLs into `nostrand/references/`, rebuild the host |
+| `dotnet build -t:MagicUnity` | deploy the runtime and stdlib into the Unity package |
+| `dotnet build -t:Clean` | remove build artifacts |
+
+With no target, MSBuild runs the project's `DefaultTargets`, `All`: `Clean`, then `Magic`, `Bootstrap` and `MagicUnity`, with `Nostrand` pulled in as a dependency of `Magic`.
+
+## Release
+
+```bash
+bb outdated         # GitHub Actions via antq, NuGet via dotnet list package
+bb verify-dist      # every shipped artifact is present and `nos version` runs
+bb release-tarball  # build, stage bin/Release/net471, tar, extract it again and run nos version
+bb tag              # verify-dist, then tag from version.edn and push
+```
+
+`bb tag` pushes and the release workflow takes it from there. Nothing else here touches the remote.

--- a/docs/native-assemblies.md
+++ b/docs/native-assemblies.md
@@ -1,88 +1,148 @@
 # Loading precompiled native assemblies
 
-A library sometimes mixes Clojure source with C# compiled ahead of time to a plain assembly committed to the repo, say a hand-written parser class built with `csc`. On the JVM the equivalent, `.class` files on a `:paths` directory, just works: the classpath is how types get resolved. The CLR has no classpath for types. `:import` only searches assemblies already loaded in the process; it never loads one. So something must call `assembly-load-from` before the `:import` runs, or the `:import` fails with a missing type.
+Some libraries ship a hand-written C# class next to their Clojure, compiled ahead of time with `csc` and committed to the repo.
 
-This is not a MAGIC quirk. ClojureCLR behaves the same way, and its `assembly-load` / `assembly-load-from` / `assembly-load-file` are the official mechanism; there is nothing higher-level, on either `cljr` or `nos`. Every CLR Clojure library that ships a precompiled assembly has to load it explicitly. The only question is where that load lives.
+On the JVM that costs you nothing, because the classpath is how types get resolved: you drop the `.class` files on a `:paths` directory and `:import` finds them.
 
-## The recommended pattern: a loader namespace
+The CLR has no classpath for types. `:import` resolves a type name against the assemblies **already loaded into the process**, and it never goes looking for a file.
+So a fresh process has no idea your DLL exists, and the `:import` fails with a missing type even though the file sits right next to your source.
+Something has to load the assembly first, which is the extra step in the diagram below.
 
-The official way to load an assembly is `assembly-load-from`, called before the `:import` runs. The common shortcut is to hardcode the DLL's path, but that breaks the moment the library is consumed from another directory. Instead, scan `CLOJURE_LOAD_PATH` (the CLR's load path) for the DLL from a small namespace, and require it from the namespace that does the `:import`. Clauses run in written order, so put the `:require` before the `:import`, and the assembly loads first. This is the plain ClojureCLR pattern, and it works unchanged on MAGIC because `nos` puts the project's `:paths` on `CLOJURE_LOAD_PATH` too:
-
-```clojure
-(ns my-lib.load-dll
-  "The CLR does not load an assembly at :import; load the compiled DLL
-   explicitly. Scan CLOJURE_LOAD_PATH, which carries the project :paths
-   on both ClojureCLR and nostrand."
-  #?(:cljr (:require [clojure.string :as str]))
-  #?(:cljr (:import [System.IO Path File])))
-
-#?(:cljr
-   (let [roots (some-> (Environment/GetEnvironmentVariable "CLOJURE_LOAD_PATH")
-                       (str/split (re-pattern (str Path/PathSeparator))))]
-     (when-let [dll (some (fn [root]
-                            (let [p (Path/Combine root "my_lib.dll")]
-                              (when (File/Exists p) p)))
-                          roots)]
-       (assembly-load-from dll))))
+```mermaid
+%% mermaid lays disconnected subgraphs out in reverse declaration order,
+%% so CLR is declared first to render JVM on the left
+flowchart TD
+    subgraph clr["CLR"]
+        direction TB
+        c0["assembly-load-from<br/>my_lib.dll"]
+        c1["(:import [my_lib MyParser])"]
+        c2["search assemblies loaded<br/>in the process, never the disk"]
+        c3["type resolved"]
+        c0 --> c1 --> c2 --> c3
+    end
+    subgraph jvm["JVM"]
+        direction TB
+        j1["(:import [my_lib MyParser])"]
+        j2["search the classpath<br/>for my_lib/MyParser.class"]
+        j3["type resolved"]
+        j1 --> j2 --> j3
+    end
 ```
 
-The importing namespace requires it in the same `ns` form:
+This is not a MAGIC limitation. [ClojureCLR](https://github.com/clojure/clojure-clr) behaves the same way, and its `assembly-load`, `assembly-load-from` and `assembly-load-file` are the mechanism both runtimes give you. MAGIC inherits them, since its stdlib is a fork of ClojureCLR's.
+
+## Recommended: a dedicated assembly loader namespace
+
+You have a small namespace that loads the DLL, required by the namespace that imports the types. The tempting shortcut is to hardcode the DLL path, but that breaks the moment someone consumes your library from another directory. Instead scan `CLOJURE_LOAD_PATH`, the environment variable both runtimes fill from the project's `:paths`. MAGIC also has a `*load-paths*` var, but it is MAGIC's own, so a loader reading it breaks under `cljr`.
+
+The loader is CLR-only, so it gets the `.cljr` extension and needs no reader conditionals:
 
 ```clojure
+;; src/my_lib/load_dll.cljr
+(ns my-lib.load-dll
+  (:require [clojure.string :as str])
+  (:import [System.IO Path File]))
+
+(let [roots (some-> (Environment/GetEnvironmentVariable "CLOJURE_LOAD_PATH")
+                    (str/split (re-pattern (str Path/PathSeparator))))]
+  (when-let [dll (some (fn [root]
+                         (let [p (Path/Combine root "my_lib.dll")]
+                           (when (File/Exists p) p)))
+                       roots)]
+    (assembly-load-from dll)))
+```
+
+The importing namespace requires it in the same `ns` form. Reader conditionals are only read in `.cljc`, so that has to be the extension here:
+
+```clojure
+;; src/my_lib/core.cljc
 (ns my-lib.core
   #?(:cljr (:require [my-lib.load-dll]))
   #?(:cljr (:import [my_lib MyParser])))
 ```
 
-Between libraries this is boilerplate: copy the loader namespace as-is and edit the one filename string. The directory holding the DLL (say `src_classes`) must be on the project's `:paths`, so the scan finds it, and the DLL should be named after the namespace prefix of the types inside it (`my_lib.MyParser` lives in `my_lib.dll`); the compiler's unloaded-DLL diagnostics match on that convention. The diagram below shows the order.
+The clauses run in written order, so the loader has put the assembly in the process by the time the `:import` runs.
 
 ```mermaid
 flowchart LR
-    req["require<br/>my-lib.core"] --> ld["my-lib.load-dll runs<br/>scans the load path"]
-    ld --> found{"DLL on<br/>a load path?"}
-    found -->|yes| al["assembly-load-from"] --> imp[":import resolves"]
-    found -->|no| pre["already loaded<br/>(Unity plugins)"] --> imp
+    req["require<br/>my-lib.core"] --> ld["my-lib.load-dll<br/>scans CLOJURE_LOAD_PATH"]
+    ld --> found{"my_lib.dll<br/>found?"}
+    found -->|yes| al["assembly-load-from"]
+    found -->|no| noop["no-op<br/>(Unity: already loaded)"]
+    al --> imp[":import resolves"]
+    noop --> imp
 ```
 
-Multiple assemblies compose through the same pattern. A library shipping several DLLs loads each one from its single loader (a `doseq` over the filenames), and libraries compose with no consumer coordination: requiring each library runs its own loader. Loads are idempotent, since `require` runs a loader once per process and `assembly-load-from` on an already-loaded path returns the cached assembly.
+Three things have to line up:
 
-## Why the load must be in-band
+- **The DLL's directory must be on the project's `:paths`.** That is what `nos` and `cljr` turn into `CLOJURE_LOAD_PATH`, so anything outside `:paths` is invisible to the scan. The directory name itself is free, `src_classes` in the examples here.
+- **It must be a top-level `:paths` entry, in `deps-clr.edn` if the library ships one.** A `:clr` alias cannot carry it, because a dependency's aliases are never applied: the directory would reach the library's own build and no consumer's.
+- **It is recommended to have the DLL named after the namespace prefix of the types inside it**, so `my_lib.MyParser` lives in `my_lib.dll`. It enables MAGIC's hint: when an `:import` fails, MAGIC searches the load path for a DLL whose name matches a namespace prefix of the missing type and points at it.
 
-Keeping the load in the require graph is what makes it work everywhere, with no toolchain support. One placement covers every case:
+Several assemblies fold into one loader with a `doseq` over the filenames, several libraries compose with no coordination from the consumer, and the whole thing is idempotent, since `require` runs a loader once per process and `assembly-load-from` on an already loaded path returns the cached assembly.
 
-- `nos build` and `nos test`: the loader runs before anything uses the type.
-- ClojureCLR's `cljr`, which puts `:paths` on the same `CLOJURE_LOAD_PATH` the loader scans.
-- Consumers pulling the library as a git dep: their require of `my-lib.core` runs the loader in their own process.
-- Unity players: the scan finds nothing and the loader is a no-op, which is correct, because assemblies under `Assets/Plugins` are already loaded.
+Note that Unity players are the one place the scan finds nothing, since `CLOJURE_LOAD_PATH` is unset there. That is correct rather than broken, because assemblies under `Assets/Plugins` are already loaded before any Clojure runs.
 
-This is also why MAGIC does not load the DLL for you. It could, but a library leaning on that would no longer load under `cljr`, and ClojureCLR is not ours to change. The loader namespace is the one form of the load both runtimes execute, so it stays in the library.
+### The in-file variant you will see in ClojureCLR libraries
+
+ClojureCLR's own sources do not use a loader namespace. They load inline, in the file that needs the types, and move the `:import` out of the `ns` form so the load can run before it. From [`clojure/clr/io.clj`](https://github.com/clojure/clojure-clr/blob/master/Clojure/Clojure.Source/clojure/clr/io.clj), abridged:
+
+```clojure
+(ns clojure.clr.io
+  (:import ...))   ; System.Net.Sockets is deliberately left out here
+
+(try
+  (assembly-load-from (str clojure.lang.RT/SystemRuntimeDirectory "System.Net.Sockets.dll"))
+  (catch Exception e))
+
+(import '[System.Net.Sockets Socket NetworkStream])
+```
+
+It works, and for a single importing namespace there is nothing wrong with it. Note that those cases know their directory up front (`RT/SystemRuntimeDirectory`), which is why they hardcode a path instead of scanning: a DLL shipped inside a library has no such fixed location.
 
 ## When the loader is missing
 
-Nothing warns ahead of time; the `:import` itself fails when it runs, and MAGIC's error names the DLL it found on the load path:
+Nothing warns you in advance. The `:import` fails when it runs, and MAGIC's error names the DLL it spotted on the load path:
 
 ```
 System.InvalidOperationException: Could not find type my_lib.MyParser during import; found /path/to/my-lib/src_classes/my_lib.dll on the load path but no loaded assembly defines this type, load it before :import, see docs/native-assemblies.md in the MAGIC repo
 ```
 
-Under `nos build` and `nos test` this surfaces while the namespace compiles; for a consumer it surfaces at `require`. The hint is MAGIC's; `cljr` fails at the same point with its own missing-type error.
+Under `nos build` and `nos test` this surfaces while the namespace compiles, and for a consumer it surfaces at `require`.
 
-## Parity libraries
+MAGIC adds a hint to guide the consumer: it appears when a DLL on the load path matches a namespace prefix of the unresolved type, and the compiler appends it to `Unable to resolve symbol` errors too.
 
-A library that must build on both ClojureCLR and MAGIC should pair the loader with a self-contained `deps-clr.edn` whose `:paths` include the DLL directory. Both `cljr` and `nos` read that one file and put every `:paths` entry on `CLOJURE_LOAD_PATH`, so the loader's scan finds the assembly on either runtime. See [Declaring CLR dependencies](./clr-dependency-files.md).
+## Building the assembly
 
-## Building the assembly against the runtime
-
-When the C# source references Clojure types, the compiler needs the runtime assemblies. `nos where` prints the directory the running host loaded them from, so a build script never guesses install dirs:
+How you drive `csc` is between you and Microsoft, with one MAGIC-specific part. When the C# references Clojure types it has to compile against the same runtime assemblies the host will load, and `nos where` prints the directory they came from, so a build script never guesses at install paths:
 
 ```bash
-csc -deterministic -target:library -r:$(nos where Clojure.dll) -out:src_classes/my_interop.dll MyInterop.cs
+csc -nologo -deterministic -target:library \
+    -reference:$(nos where Clojure.dll) \
+    -out:src_classes/my_lib.dll MyLib.cs
 ```
 
-The `-deterministic` flag is what keeps the committed DLL byte-stable: without it, `csc` stamps a random module id, so rebuilding unchanged source modifies the committed file every time. Byte-stability also needs a pinned `AssemblyVersion` (a `1.0.*` wildcard derives the version from the build time) and the same compiler version across rebuilds, so expect a toolchain upgrade to change the bytes once. If the build emits debug info (`-debug:portable`), add `-pathmap:"$PWD"=/src` so the embedded source paths do not tie the bytes to one checkout directory.
+`-deterministic` is there because the DLL is committed: without it Roslyn stamps a fresh module id and timestamp into every build, so rebuilding unchanged source dirties `git status` and you learn to ignore real changes. Mono's older `mcs` produces stable bytes without the flag and accepts it silently, so a build script can pass it always instead of detecting which compiler is installed.
 
-## See also
+One trap survives the flag rather than being caused by it. The assembly and module identity come from the `-out:` basename, and every C# compiler writes them into the metadata, so renaming the file afterwards does not rename the module inside it. Compiling to a temp name and moving it into place therefore produces a different DLL than compiling straight to the committed name. A temp directory is fine, a temp name is not. Without `-deterministic` you would never notice, because every rebuild churns anyway.
 
-- [Declaring CLR dependencies](./clr-dependency-files.md)
-- [Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md)
-- [Writing cross-platform Clojure](./writing-cross-platform-clojure.md)
+```bash
+# stable: the module name is my_lib, the name the committed DLL already has
+csc -deterministic -out:/tmp/build/my_lib.dll MyLib.cs
+mv /tmp/build/my_lib.dll src_classes/
+
+# not stable: the module name is tmp, so the bytes differ from the committed DLL
+csc -deterministic -out:/tmp/build/tmp.dll MyLib.cs
+mv /tmp/build/tmp.dll src_classes/my_lib.dll
+```
+
+[Deterministic compilation](./deterministic-compilation.md) covers why this repo cares so much about that property.
+
+## If the assembly ships into a Unity player
+
+The Clojure side of a library is compiled by MAGIC and already survives IL2CPP. Your C# is not, so it carries the constraints of whatever profile the player uses. Two of them bite:
+
+- **No runtime codegen.** `System.Reflection.Emit`, `Expression.Compile`, dynamic proxies: all of it works under Mono and throws under IL2CPP, which has no JIT. `nos test` will not catch this, since it runs on Mono.
+- **Reflection over types nothing references statically** can be stripped from the player. Managed stripping keeps what it can see, so a type resolved only by name at runtime may be gone by the time you ask for it.
+
+Neither is MAGIC-specific, but neither shows up until the IL2CPP build, which is the expensive place to find out. If the library is meant for Unity, exercise it in a player before you tag a release.

--- a/docs/nos-cli.md
+++ b/docs/nos-cli.md
@@ -1,0 +1,148 @@
+# The `nos` CLI
+
+`nos` is for MAGIC what `clj` is for JVM Clojure and `cljr` is for ClojureCLR: the command that resolves your dependencies and runs your code. MAGIC needs one because it is a compiler and nothing more: it turns Clojure forms into MSIL and has no idea what a dependency or a test suite is.
+
+`nos` is a C# executable that loads the committed compiler, resolves a `deps-clr.edn` or `deps.edn`, puts the resolved source paths on the load path, and then calls a Clojure function you name. Everything else it does is a function running inside that.
+
+That last part is the shape worth holding on to. `nos` has no build DSL and no lifecycle. A task is a plain Clojure `defn`, and `nos build` is a `defn` that happens to ship with the host.
+
+## Finding a task
+
+```mermaid
+flowchart TD
+    arg["nos &lt;name&gt; [args...]"] --> slash{"does the name<br/>contain a slash?"}
+    slash -->|"yes: dotnet/build"| load["load the namespace from<br/>the load path (dotnet.clj)"]
+    load --> v1["call that namespace's var"]
+    slash -->|"no: build"| bi{"a var in<br/>nostrand.tasks?"}
+    bi -->|yes| v2["call the built-in"]
+    bi -->|no| core{"a var in<br/>clojure.core?"}
+    core -->|yes| v3["call that"]
+    core -->|no| file{"a source file in<br/>the current directory?"}
+    file -->|"yes: script.clj"| v4["load it, call its -main"]
+    file -->|no| fail["not found"]
+```
+
+So `nos dotnet/build` loads `dotnet.clj` from the current directory and calls `build` in it. The file name carries no meaning: `nos release/publish` loads `release.clj` just as happily. `dotnet.clj` is a convention inherited from the projects that came first, not a name the host knows.
+
+Arguments are read as EDN, the whole command line at once. When that fails to read, `nos` retries argument by argument and passes any that still will not read through as a symbol, which is what lets an absolute path work: `/Users/me/f.clj` is not readable EDN, so it arrives as a symbol of that name.
+
+`nos tasks` prints the docstring of every public var in every `.clj` file in the current directory. It documents your task files, not the built-ins.
+
+## `nos build` and `nos test`
+
+Two of the tasks that ship with the host do the work a project needs, which is why most projects need no task file at all.
+
+```bash
+nos build    # compile the project's namespaces into ./build
+nos test     # run its clojure.test suites, exit 1 on any failure or error
+```
+
+Both derive the set of namespaces they work on rather than being told. They resolve the deps file, collect the source paths it contributes (the base `:paths`, plus the `:extra-paths` of each activated alias), and scan those directories recursively for `.clj`, `.cljc` and `.cljr` files, taking the namespace each one declares.
+
+Neither task takes an alias flag. What they work on comes from a file.
+
+## `magic.edn`
+
+`magic.edn` is a convenience file to configure the build and test tasks as pure EDN at the project root.
+
+It is a map with a `:build` and a `:test` sub-map. Every key has a default, so state only what differs, and omit the file entirely when nothing does.
+
+```clojure
+;; magic.edn
+{:test {:aliases [:clr :test]}}
+```
+
+`nos test` turns that map into the call a task file would write by hand, `(tasks/run-clojure-tests :aliases [:clr :test])`, and `nos build` does the same with `:build` and `tasks/compile-project`. The file is pure configuration over `nostrand.tasks`, the functions [Task files](#task-files) below compose directly.
+
+| Key | `:build` | `:test` | Meaning | Default |
+|---|:-:|:-:|---|---|
+| `:aliases` | yes | yes | deps aliases to activate | none, and `[:test]` for `:test` |
+| `:namespaces` | yes | yes | explicit set, replacing the derivation | derived from the source paths |
+| `:exclude` | yes | yes | namespaces to drop from the set | none |
+| `:flags` | yes | yes | compiler flag overrides | the sets below |
+| `:out` | yes | | compile output directory | `"build"` |
+| `:clean?` | yes | | wipe `:out` first | `true` |
+| `:re` | | yes | regex string scoping the run | the derived namespaces |
+| `:exclude-vars` | | yes | `deftest` symbols to skip | none |
+
+The file is spec-checked on read, so a malformed value fails with an explanation naming the key path.
+
+Note the following:
+
+- **`:re`** is matched with `re-matches`, so it has to match a namespace name whole. Write it as a string, since EDN has no regex literal: `"my\\.lib\\..*"`.
+- **`:exclude-vars`** takes fully-qualified `deftest` symbols. After `require`, the run clears the `:test` metadata on each, so `clojure.test` skips exactly those vars and the rest of their namespace still runs. It is for a handful of platform-specific failures scattered through otherwise-passing namespaces, where excluding the namespace would throw away good tests. A symbol that does not resolve warns rather than failing.
+- **`:namespaces`** is the escape hatch for what the derivation cannot see: a single compile root, or a vendored namespace no `require` reaches.
+
+## Compiler flags
+
+`nos build` compiles under the flags a shipped MAGIC project runs on:
+
+```clojure
+{#'*unchecked-math*                true
+ #'*warn-on-reflection*            true
+ #'magic.flags/*strongly-typed-invokes* true
+ #'magic.flags/*direct-linking*         true
+ #'magic.flags/*elide-meta*             false}
+```
+
+- `*unchecked-math*`: integer arithmetic compiles to raw CIL ops, no overflow checks.
+- `*warn-on-reflection*`: interop the compiler cannot resolve statically warns at compile time.
+- `*strongly-typed-invokes*`: a call whose `Magic.Function` type is statically known lowers to a typed interface call, skipping argument boxing.
+- `*direct-linking*`: a call to a non-variadic, non-dynamic fn lowers to a direct `invokeStatic`, bypassing the Var.
+- `*elide-meta*`: metadata expressions are dropped during analysis. Pinned off.
+
+These five are what the built-ins set. The full surface, spells included, is [`magic.flags`](../magic-compiler/src/magic/flags.clj), one docstring per var.
+
+`nos test` uses the same set with `*direct-linking*` and `*strongly-typed-invokes*` turned **off**, and that is not a detail: both lower a call so it no longer goes through the Var, so `with-redefs` has nothing left to rebind. Tests that mock would silently keep calling the real function.
+
+The consequence is worth stating plainly. A green `nos test` says nothing about whether your library compiles and runs under the flags `nos build` uses. [Writing cross-platform Clojure](./writing-cross-platform-clojure.md) covers the code patterns that break only under those flags.
+
+`:flags` merges over whichever base applies, so name the vars you change as fully-qualified symbols.
+
+```clojure
+{:build {:flags {magic.flags/*elide-meta* true}}}
+```
+
+## Task files
+
+A task file is a namespace with public functions. It exists for work the built-ins do not do.
+
+```clojure
+;; publish.clj
+(ns publish
+  (:require [nostrand.tasks :as tasks]))
+
+(defn nuget [] ...)
+```
+
+`nostrand.tasks` holds the pieces the built-ins are made of, so a custom task composes them instead of restating them. `compile-project` and `run-clojure-tests` take the same options as the `magic.edn` keys above, `production-flags` and `test-flags` are the two flag maps, and `project-namespaces` returns the derived set without touching the load path.
+
+Older projects wrote a `dotnet.clj` defining `build` and `run-tests` by hand, before the built-ins existed. Those still work unchanged, and `nos dotnet/build` and `nos build` coexist in the same project.
+
+```clojure
+(ns dotnet
+  (:require [nostrand.tasks :as tasks]))
+
+(defn build     [] (tasks/compile-project :clean? true))
+(defn run-tests [] (tasks/run-clojure-tests :aliases [:test]))
+```
+
+One difference to know if you keep one: `compile-project` defaults `:clean?` to `false`, while `nos build` defaults it to `true`.
+
+## Diagnostics
+
+| Command | What it tells you |
+|---|---|
+| `nos version` | the versions of the host, both C# runtimes, Clojure, and the CLR underneath |
+| `nos where` | the directory the running host loaded `Clojure.dll` from |
+| `nos where Clojure.dll` | that one assembly's full path, as bare stdout for `$(...)` capture |
+| `nos print-basis [:alias ...]` | the resolved paths and libs, without compiling |
+| `nos repl` | a REPL on a warm runtime |
+
+`nos where` is what a build script uses to compile C# against the same runtime the host will load, instead of guessing at install paths ([native assemblies](./native-assemblies.md)). `nos print-basis` is the one to reach for when a namespace is missing and you cannot tell whether the dependency resolved ([declaring CLR dependencies](./clr-dependency-files.md)).
+
+## What `nos test` cannot catch
+
+`nos test` runs on Mono, which compiles at run time. Unity players use IL2CPP, which compiles to C++ ahead of time and has no JIT at all, so a whole class of failure exists only there: anything that emits code at run time, and anything reflected over that static analysis cannot see and stripping therefore removes.
+
+No Mono run reaches those. A player build is the only thing that does ([Unity integration](./unity-integration.md)).

--- a/docs/porting-libraries-to-magic.md
+++ b/docs/porting-libraries-to-magic.md
@@ -1,131 +1,102 @@
 # Porting a Clojure library to MAGIC
 
-How to take an existing Clojure library and compile and test it on the CLR with MAGIC. Assumes `nos` is installed (see the [Install](../README.md#install) section).
+Taking a library that runs on the JVM and making it compile and test on the CLR. Four steps, and this page is the order to do them in. Each links to the page that covers it, and the two things nothing else covers, testing and CI, are here in full.
 
-The work is in three parts: make the source cross-platform, declare paths and deps in `deps.edn`, and configure build and test in `magic.edn`.
+Assumes `nos` is installed ([Install](../README.md#install)).
 
-## 1. Make the source cross-platform
-
-MAGIC runs the same source the JVM does, through Clojure [reader conditionals](https://clojure.org/guides/reader_conditionals). Rename `.clj` files to `.cljc` and gate the platform-specific parts (interop, `require`/`import`, type hints) behind `:cljr`:
-
-```clojure
-(defn round
-  #?(:clj  [n]
-     :cljr [^double n])
-  #?(:clj  (Math/round n)
-     :cljr (Math/Round n)))
+```mermaid
+flowchart LR
+    s1["1. make the source<br/>cross-platform"] --> s2["2. declare the<br/>CLR deps"]
+    s2 --> s3["3. configure build<br/>and test"]
+    s3 --> s4["4. run the tests,<br/>then wire up CI"]
 ```
 
-Only `:clj` and `:cljr` branches are needed; there is no third platform to default to. Keep type hints inside `:cljr` so the JVM stays dynamically typed and your existing tests keep passing. The full flag and type-hint surface is in [`magic-compiler/src/magic/flags.clj`](../magic-compiler/src/magic/flags.clj).
+**1. Make the source cross-platform.** Move anything with host interop to `.cljc` and use reader conditional `:cljr` for the CLR parts. The extension precedence, the type hints worth adding, the host APIs that genuinely differ, and the Clojure 1.10 boundary are all in [writing cross-platform Clojure](./writing-cross-platform-clojure.md).
 
-For the source patterns in depth (value-type and reference-type hints, records and protocols, the host APIs that genuinely differ, and the Clojure 1.10 stdlib surface) see [Writing cross-platform Clojure](./writing-cross-platform-clojure.md).
+**2. Declare the CLR deps.** Write a `deps-clr.edn` at the project root with the CLR coordinates. Both `nos` and `cljr` read it in place of `deps.edn`, so the JVM file stays untouched and the library also builds under ClojureCLR. [Declaring CLR dependencies](./clr-dependency-files.md) covers that file, the older `:clr` alias alternative, and how `nos` resolves what you write.
 
-## 2. deps.edn
+**3. Configure build and test.** A `magic.edn` at the root states what differs from the defaults, usually the aliases and little else. `nos build` and `nos test` read it. The full option surface, the compiler flags each task uses, and custom task files are in [the `nos` CLI](./nos-cli.md).
 
-`nos` resolves `deps.edn` natively (git and local deps; it clones git deps into `$GITLIBS` if set, else `~/.nostrand/gitlibs`, at boot). Declare your source `:paths` and put test sources under a `:test` alias so they only load when testing:
+**4. Run the tests and wire up CI.** The rest of this page.
+
+If the library ships a precompiled C# assembly next to its Clojure, it needs a loader namespace as well: see [loading precompiled native assemblies](./native-assemblies.md).
+
+## Running the tests: two runners, not one
+
+A library that builds on both ClojureCLR and MAGIC is tested by two different runners, and they want different things from the same `deps-clr.edn`.
+
+`cljr -X:test` has no test runner of its own, so the alias carries one. This is [`fun-map`](https://github.com/robertluo/fun-map)'s, and it is the shape you will see across CLR libraries that were ported and tested with ClojureCLR:
 
 ```clojure
+;; deps-clr.edn
 {:paths ["src"]
- :deps  {}
- :aliases {:test {:extra-paths ["test"]}}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {io.github.dmiller/test-runner
+                       {:git/tag "v0.5.3clr"
+                        :git/sha "ae91dd2727bbf70eb3a6d869a19953de3819dfbc"}}
+         :exec-fn     cognitect.test-runner.api/test
+         :exec-args   {:dirs ["test"]}}}}
 ```
 
-When a library needs CLR-specific dependencies (a CLR fork of a JVM library, for instance), declare them either in a `deps-clr.edn` or a `:clr` alias. See [Declaring CLR dependencies](./clr-dependency-files.md) for which one fits. If the library ships a precompiled C# assembly alongside its Clojure source, it also needs a small loader namespace to load that DLL on the CLR: see [Loading precompiled native assemblies](./native-assemblies.md).
-
-## 3. magic.edn
-
-`nos` has built-in `build` and `test` tasks. They read an optional `magic.edn` at the project root: a map with `:build` and `:test` option sub-maps. A project states only what differs from the defaults, so most `magic.edn` files are a few lines, and a project that needs no tweaks can omit the file entirely.
+`nos test` cannot use this test-runner. It drives `clojure.test` directly, derives the namespace set from the source paths the aliases contribute, and takes its configuration from `magic.edn`:
 
 ```clojure
 ;; magic.edn
-{:build {:aliases [:clr]}
- :test  {:aliases [:clr :test]}}
+{:test {:aliases [:test]}}
 ```
-
-### Options
-
-| Key | build | test | Meaning | Default |
-|-----|:-:|:-:|---|---|
-| `:aliases`    | yes | yes | deps aliases to activate | none (test: `[:test]`) |
-| `:namespaces` | yes | yes | explicit namespaces, overrides derivation | derived from paths |
-| `:exclude`    | yes | yes | namespaces to drop from the set | none |
-| `:re`         |     | yes | regex string scoping the run (`re-matches`) | the project's own namespaces |
-| `:exclude-vars` |   | yes | fully-qualified `deftest` symbols to skip | none |
-| `:flags`      | yes | yes | flag overrides (see below) | build: production, test: test-friendly |
-| `:out`        | yes |     | compile output dir | `"build"` |
-| `:clean?`     | yes |     | wipe `:out` first | `true` |
-
-Defaults when a key is omitted:
-
-- `:namespaces`: derived from the paths the aliases contribute (base `:paths` for build; plus the test alias's `:extra-paths` for test).
-- `:re`: the test run is scoped to the project's own namespaces (its suites run, its dependencies' bundled suites do not). Write it as a string, e.g. `"my\\.lib\\..*"`; EDN has no regex literal.
-- `:exclude-vars`: a vector of fully-qualified `deftest` symbols the run clears the `:test` meta on after `require`, so `clojure.test` skips exactly those vars while the rest of their namespace still runs. Use it for a few platform-specific failures scattered inside otherwise-passing namespaces (a Windows-only newline expectation, a Mono-only numeric edge case), where excluding the whole namespace would drop good tests too.
-
-### Flags
-
-`:flags` overrides the compilation flags for the run. EDN cannot hold a var, so name each flag as a fully-qualified symbol:
-
-```clojure
-{:build {:flags {magic.flags/*elide-meta* true}}}
-```
-
-`build` starts from the production flag set (`*direct-linking*`, `*strongly-typed-invokes*`, `*elide-meta*`, `*unchecked-math*`, `*warn-on-reflection*`). `test` starts from the same set with `*direct-linking*` and `*strongly-typed-invokes*` off, since `with-redefs` cannot rebind a direct-linked or strongly-typed call. Your `:flags` merge over that base, so state only what you change.
-
-### More examples
-
-Exclude a namespace that must not compile on the CLR (a ClojureScript-only or JVM-only one):
-
-```clojure
-{:build {:exclude [my.lib.frontend.cljs]}
- :test  {:exclude [my.lib.frontend.cljs]}}
-```
-
-State the compile roots and output directory explicitly (a Unity plugins build, or a vendored namespace not reachable by `require`):
-
-```clojure
-{:build {:namespaces [my.lib.core my.lib.api]
-         :out        "Assets/Plugins/Magic"}}
-```
-
-Skip individual tests that fail only for platform reasons (a Windows CRLF expectation, a Mono numeric edge case), keeping the rest of their namespaces:
-
-```clojure
-{:test {:exclude-vars [my.lib-test/windows-newline-test
-                       my.lib.suite-test/huge-exponent-test]}}
-```
-
-### The old way: dotnet.clj
-
-Before the built-in tasks, each project wrote a `dotnet.clj` defining `build`/`run-tests` by hand over `nostrand.tasks`. It stays backward compatible: existing `dotnet.clj` files still work unchanged, and `nos dotnet/build` and `nos build` coexist.
-
-```clojure
-(ns dotnet
-  (:require [nostrand.tasks :as tasks]))
-
-(defn build     [] (tasks/compile-project :aliases [:clr] :clean? true))
-(defn run-tests [] (tasks/run-clojure-tests :aliases [:clr :test]))
-```
-
-`magic.edn` exposes the full option set of both tasks, so a ported library needs no `dotnet.clj`; write one only for a project that also defines its own unrelated `nos` tasks.
-
-## 4. Build and test
 
 ```bash
-nos build    # compiles to ./build (or :out)
-nos test     # runs the project's clojure.test suites, exits non-zero on failure
+nos test     # exits 1 on any failure or error
 ```
 
-`nos test` runs under Mono and does not cover IL2CPP codegen; for Unity, an actual IL2CPP build is the only way to catch AOT-only regressions (see [`magic-unity-smoke`](../unity-examples/magic-unity-smoke)).
+So the two ways to test coexist: the test runner in the `deps-clr.edn` test alias for `cljr`, `magic.edn` for `nos`. `:exec-fn` and `:exec-args` are ignored **silently** by `nos`: they are not on the list of keys it warns about, so nothing tells you they had no effect on a `nos test` run.
 
-## 5. CI
+### Why `nos` does not use ClojureCLR's runner
 
-A CI job needs `mono` and `nos` (see [Install](../README.md#install)). Flybot publishes a prebuilt image for this, [`ghcr.io/flybot-sg/ci-clj-clr`](https://github.com/flybot-sg/ci-clj-clr) (JDK, Clojure CLI, Babashka, Mono, and a pinned `nos`), so one container runs both JVM and CLR test jobs; pin the tag that ships the MAGIC version you build against. [flybot-sg/clr.test.check](https://github.com/flybot-sg/clr.test.check) (the `magic` branch) is a worked example, adding this CI on top of David Miller's upstream port. Any image with `mono` plus the `nos` installer works just as well if you would rather not depend on it.
+It looks like duplicated effort, and the reason it is not comes down to what the runner is built on rather than to the runner itself.
 
-### Caching
+```mermaid
+flowchart TD
+    alias["the :test alias<br/>exec-fn cognitect.test-runner.api/test"]
+    alias -->|"cljr -X:test"| tr["dmiller/test-runner"]
+    tr --> tn["clr.tools.namespace"]
+    tn --> trd["clr.tools.reader"]
+    trd --> refl["needs clojure.lang.Reflector<br/>for record-literal reading"]
+    refl --> absent["absent from MAGIC's runtime"]
+    alias -->|"nos test"| nat["native discovery<br/>+ clojure.test"]
+```
 
-Point `GITLIBS` at a path inside the checkout so the runner can persist git deps across pipelines. `nos` honours the same variable JVM tools.deps uses (cloning under `$GITLIBS/nostrand/`, which cannot collide with the JVM entries), so one setting covers both the JVM and CLR jobs. GitLab example:
+`clr.tools.reader` reads record literals through `Reflector/InvokeConstructor` and `Reflector/InvokeStaticMethod`, which is runtime reflection over types chosen while the program runs. MAGIC's forked runtime does not ship `Reflector`, because resolving calls that way is the thing IL2CPP cannot do and the thing MAGIC exists to eliminate. So the chain stops in the first dependency, before it ever reaches the runner. Two smaller incompatibilities sit in front of that one and are both fixable, but this one is a design divergence: making it load would mean putting reflection back.
+
+Nothing is lost, because the chain is redundant here. A test runner does four things: find test namespaces in some directories, load them, run `clojure.test`, and filter vars by metadata. `nos` already discovers namespaces by scanning those directories and reading each `ns` form with MAGIC's own reader, and `clojure.test` needs no help with the rest. `clr.tools.namespace` and `clr.tools.reader` exist to do the first step on a runtime without a compiler in it. MAGIC is a compiler.
+
+The practical consequence for a dual-runtime library is small: keep the `cljr` runner in the alias for `cljr -X:test`, add a `magic.edn` for `nos test`, and expect both to run the same suites.
+
+Two limits on a green `nos test`. It runs with direct linking and strongly-typed invokes off, so it says nothing about whether the library works under the flags `nos build` uses. And it runs on Mono, so it cannot reach the IL2CPP failures that only a Unity player build produces ([Unity integration](./unity-integration.md)).
+
+## Rich comment tests
+
+If the library's tests are [rich comment tests](https://github.com/robertluo/rich-comment-tests), they cannot run on the CLR as they stand: RCT extracts its assertions at run time through `rewrite-clj` and other JVM-only machinery.
+
+[flybot-sg/rct-clr](https://github.com/flybot-sg/rct-clr) bridges it in one direction. On the JVM it reads the rich comments and writes out a plain `.cljc` file of ordinary `deftest` forms asserting with [matcho](https://github.com/flybot-sg/matcho). MAGIC then runs that generated file with nothing but `clojure.test` and `matcho.core`.
+
+The rich comments themselves are inert on the CLR: they sit in `src` and the generated file carries the assertions. What cannot load is the JVM test namespace whose `deftest` calls the RCT runner, so exclude that one and let the generated namespace run like any other suite:
+
+```clojure
+{:test {:exclude [my.lib.rct-test]}}
+```
+
+Generation runs on the JVM, so `nos test` follows a `clojure -M:dev -m rct-clr.gen -o <file> -n <ns>` step rather than replacing it. `matcho` is the one extra CLR dependency it costs.
+
+## CI
+
+A job needs `mono` and `nos`. Flybot publishes [`ghcr.io/flybot-sg/ci-clj-clr`](https://github.com/flybot-sg/ci-clj-clr) with JDK, Clojure CLI, Babashka, Mono and a pinned `nos`, so one container runs both the JVM and CLR jobs. Pin the tag matching the MAGIC version you build against.
+
+Git deps also have to survive between pipelines, and where that cache can live differs by platform. GitLab only caches paths inside the checkout, so move the cache there with `GITLIBS`. `nos` honours the same variable JVM tools.deps does, cloning under `$GITLIBS/nostrand/` where it cannot collide with the JVM entries, so one setting covers both jobs:
 
 ```yaml
+# .gitlab-ci.yml
 variables:
   GITLIBS: $CI_PROJECT_DIR/.gitlibs
 
@@ -136,21 +107,6 @@ cache:
     - .cpcache/
 ```
 
-Use an absolute path (`$CI_PROJECT_DIR`-based, not a bare relative one): a relative `GITLIBS` resolves against the working directory of whichever process reads it.
+Make it absolute, built from `$CI_PROJECT_DIR`. A relative `GITLIBS` resolves against the working directory of whichever process reads it, which is not the same directory for every step.
 
-## Rich-comment-tests on the CLR
-
-If a library's tests are written as [rich comment tests](https://github.com/robertluo/rich-comment-tests) (RCT), they cannot run on the CLR as-is: RCT extracts assertions at runtime using `rewrite-clj` and other JVM-only machinery. [flybot-sg/rct-clr](https://github.com/flybot-sg/rct-clr) bridges this: on the JVM it reads the rich comments and emits a plain `.cljc` test file of ordinary `deftest` forms that assert with [matcho](https://github.com/flybot-sg/matcho). MAGIC then runs that generated file with just `clojure.test` and `matcho.core`.
-
-The split shows up in `magic.edn`: `:exclude` the RCT source namespace (the rich comments plus the JVM-only extraction tooling), leaving the generated `deftest` namespace to run like any other suite. `matcho` is the one extra CLR dependency (see [Declaring CLR dependencies](./clr-dependency-files.md)); this example activates it through a `:clr` alias:
-
-```clojure
-{:test {:aliases [:clr :test]
-        :exclude [my.lib.rct-test]}}
-```
-
-The `clojure.test` assertion count on the CLR will not be one-for-one with a JVM run that executes the rich comments directly: RCT and the generated `deftest`s tally assertions differently (one `=>` expectation can expand to several matcho checks). The count differs; the same expectations are all verified.
-
-## Reference
-
-[flybot-sg/clr.test.check](https://github.com/flybot-sg/clr.test.check) is a fork of `clojure/test.check` ported with this workflow: reader conditionals throughout, cross-platform `deps.edn`, and CLR tests run under `nos`.
+GitHub Actions has nothing to relocate: add `~/.nostrand/gitlibs`, where `nos` clones when `GITLIBS` is unset, to the `actions/cache` paths and leave the variable alone.

--- a/docs/unity-integration.md
+++ b/docs/unity-integration.md
@@ -39,27 +39,29 @@ This is the consumer-side guide. For what the package contains and how its inter
 
 ## Choosing a variant
 
+> **Being retired:** an upcoming release replaces the two variants with a single package that embeds the ClojureCLR runtime and excludes MAGIC's DLLs from the Editor through `defineConstraints` in committed `.meta` files. The variant choice below, `magic-unity-dual`, and `bb gen-unity-dual` all disappear with it.
+
 The package ships in two variants, identical except for whether the runtime `.clj.dll` plugins are visible to the Editor:
 
 | | `sg.flybot.magic.unity` (default) | `sg.flybot.magic.unity.dual` |
 |---|---|---|
 | Runtime in the Editor | loadable | excluded (`!UNITY_EDITOR`) |
-| MAGIC in Editor Play mode | works | not available (Editor uses stock ClojureCLR) |
-| Alongside stock ClojureCLR | benign console noise, handled by the guard | silent (runtime absent from the Editor) |
+| MAGIC in Editor Play mode | works | not available (Editor uses ClojureCLR) |
+| Alongside ClojureCLR | benign console noise, handled by the guard | silent (runtime absent from the Editor) |
 | Player builds (Mono / IL2CPP) | identical | identical |
 
-- **Default** if MAGIC runs in your Editor (Play mode, edit-mode tooling) and there is no stock ClojureCLR.
-- **`.dual`** if your Editor runs stock ClojureCLR (REPL / hot-reload) and MAGIC ships only in player builds. Pin `?path=magic-unity-dual#<tag>`.
+- **Default** if MAGIC runs in your Editor (Play mode, edit-mode tooling) and there is no ClojureCLR.
+- **`.dual`** if your Editor runs ClojureCLR (REPL / hot-reload) and MAGIC ships only in player builds. Pin `?path=magic-unity-dual#<tag>`.
 
 Full comparison and rationale: [magic-unity, Package variants](../magic-unity/README.md#package-variants).
 
-## Coexistence with stock ClojureCLR
+## Coexistence with ClojureCLR
 
-A project that keeps stock ClojureCLR in the Editor and ships MAGIC in players runs both runtimes. With the **default** variant the Editor prints one benign `Assembly is incompatible with the editor` line per runtime `.clj.dll` on each domain reload (Unity narrating the intended exclusion; player builds are unaffected). The **`.dual`** variant excludes the runtime from the Editor by construction, so those lines never appear. Either way the stock probe for `clojure.core.clj` is kept away from the fork assemblies ([#25](https://github.com/flybot-sg/magic/issues/25)).
+A project that keeps ClojureCLR in the Editor and ships MAGIC in players runs both runtimes. With the **default** variant the Editor prints one benign `Assembly is incompatible with the editor` line per runtime `.clj.dll` on each domain reload (Unity narrating the intended exclusion; player builds are unaffected). The **`.dual`** variant excludes the runtime from the Editor by construction, so those lines never appear. Either way the fork assemblies stay out of the Editor domain, which is what stops ClojureCLR's namespace resolution from reaching them ([#25](https://github.com/flybot-sg/magic/issues/25)).
 
 The in-repo reproduction is [`unity-examples/magic-unity-coexist`](../unity-examples/magic-unity-coexist): `bb coexist-noise` checks that the dual variant is silent, `bb coexist-noise magic-only` reproduces the noise on the default variant.
 
 ## Examples
 
 - [`unity-examples/magic-unity-smoke`](../unity-examples/magic-unity-smoke): standalone IL2CPP regression suite. The reference pattern for `deps.edn` and a custom `dotnet.clj`, with a `MAGIC -> Smoke -> Build & Run IL2CPP` menu. Run by hand on Unity 2022.3.62f3.
-- [`unity-examples/magic-unity-coexist`](../unity-examples/magic-unity-coexist): coexistence repro that vendors stock ClojureCLR, driven by `bb coexist-noise`.
+- [`unity-examples/magic-unity-coexist`](../unity-examples/magic-unity-coexist): coexistence repro that vendors ClojureCLR, driven by `bb coexist-noise`.

--- a/docs/why-magic.md
+++ b/docs/why-magic.md
@@ -1,55 +1,110 @@
 # Why MAGIC
 
-MAGIC (Morgan And Grand Iron Clojure) is a Clojure compiler that targets the Common Language Runtime (.NET). It exists to satisfy one requirement the JVM Clojure compiler and the existing .NET port cannot meet together: running Clojure in Unity on platforms that forbid runtime code generation, notably iOS.
+Unity games ship to iOS, and iOS does not let a program write new executable code while it runs. The Clojure compiler for .NET does exactly that, at every dynamic call site. So we cannot use it to target iOS devices.
+
+MAGIC (Morgan And Grand Iron Clojure) exists to close that gap. It is a [bootstrapped](./bootstrap.md) Clojure compiler that targets the Common Language Runtime (.NET) and writes every instruction ahead of time, so there is nothing left to generate once the app is on the device. This allows people to compile their Clojure libs for the CLR, call them in their Unity apps, and more importantly **build to iOS** (via IL2CPP).
 
 ## The problem: AOT platforms forbid runtime codegen
 
-There is already a Clojure-to-.NET compiler, [ClojureCLR](https://github.com/clojure/clojure-clr), David Miller's port. It runs well on desktop, but it cannot ship on iOS.
+Clojure on .NET already existed before MAGIC, and it cannot ship on a phone.
 
-ClojureCLR leans on the DLR (Dynamic Language Runtime) for dynamic dispatch, and the DLR builds call sites by emitting IL at runtime through `System.Reflection.Emit`. That is a form of JIT (Just-In-Time) compilation: new executable code is produced while the program runs.
+That port is [ClojureCLR](https://github.com/clojure/clojure-clr), maintained by David Miller, and it runs well on the desktop. Its dynamic dispatch goes through the [DLR](https://learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/dynamic-language-runtime-overview) (Dynamic Language Runtime), which builds each call site by emitting IL at runtime through `System.Reflection.Emit`. IL is the bytecode the .NET runtime executes, so this is a form of JIT (Just-In-Time) compilation: new executable code is produced while the program runs.
 
-Two production constraints make that impossible on the platforms Unity games ship to:
+The problem is that iOS refuses to run code the app wrote for itself. iOS enforces **W^X** (Write XOR Execute): a memory page is either writable or executable, never both, so an app may not generate machine code and then run it. Apple rejects apps that try.
 
-- **iOS enforces W^X (Write XOR Execute).** A memory page is either writable or executable, never both, so an app may not generate and then run new machine code at runtime. Apple rejects apps that try.
-- **IL2CPP is an ahead-of-time (AOT) compiler.** Unity's production scripting backend converts every .NET assembly to C++ at build time, then compiles that to native code. It can only translate IL that already exists in the assemblies. IL that a program intends to emit later, at runtime, is not there to translate.
+So a Unity game bound for iOS has always been compiled ahead of time, since long before IL2CPP existed: Mono's full-AOT mode did that job from 2008. Today [IL2CPP](https://docs.unity3d.com/6000.5/Documentation/Manual/scripting-backends-il2cpp.html), Unity's production scripting backend, is what does it. IL2CPP converts every .NET assembly to C++ at build time and compiles that to native code, so it can only translate IL that already exists in the assemblies. IL a program intends to emit later is not there to translate, and Unity says so plainly: an ahead-of-time (AOT) platform [cannot implement any of the methods](https://docs.unity3d.com/Manual/scripting-restrictions.html) in `System.Reflection.Emit`, so the call fails rather than doing nothing.
 
-So a compiler that defers any code generation to runtime cannot run under IL2CPP, and cannot ship on iOS.
+The diagram below follows the same code down both backends, and shows where the DLR stops working.
+
+```mermaid
+flowchart LR
+    clj["mylib.clj"] -->|"ClojureCLR compiles"| dll["mylib.clj.dll<br/>(IL)"]
+
+    dll -->|"Mono backend:<br/>JIT on the device"| mono["machine code"]
+    mono -->|"a dynamic call site<br/>asks for new IL"| ok["the DLR emits it,<br/>the JIT compiles it ✅"]
+
+    dll -->|"IL2CPP transpiles,<br/>at build time"| cpp["C++ source"]
+    cpp -->|"the platform's<br/>C++ compiler"| nat["native code"]
+    nat -->|"the same call site<br/>asks for new IL"| ko["Reflection.Emit is not<br/>implemented under IL2CPP ❌"]
+```
+
+That restriction now follows IL2CPP rather than the platform that first imposed it. An Android or desktop project picks IL2CPP for its own reasons and gives up runtime code generation as part of the deal, even though the OS there would have allowed it. So a compiler that defers any code generation to runtime cannot ship on iOS, and cannot run under IL2CPP anywhere.
 
 ## What MAGIC does differently
 
-MAGIC produces fully static MSIL bytecode. Every function call, protocol dispatch, and dynamic call site is lowered to a static IL pattern at compile time. Nothing is emitted at runtime. The `.clj.dll` assemblies MAGIC writes contain all the IL the program will ever run, so IL2CPP can translate them to C++ ahead of time and the result satisfies W^X.
+MAGIC writes all the IL at build time, so the device never has to.
 
-Emitting all IL statically also gives MAGIC direct control over the bytecode it produces, which helps where JVM and CLR semantics diverge (value types, generics). This is a different set of trade-offs from a DLR-based port, not a wholesale improvement: the DLR's runtime code generation buys flexibility, at the cost of the AOT compatibility MAGIC needs for iOS and IL2CPP.
+Every function call, protocol dispatch, and dynamic call site is lowered to a static IL pattern at compile time. The `.clj.dll` assemblies MAGIC writes hold all the IL the program will ever run, so IL2CPP has everything it needs to translate them to C++, and W^X is never challenged. The diagram below is the same journey as the one above, this time compiled by MAGIC. Both backends now reach the end.
+
+```mermaid
+flowchart LR
+    clj["mylib.clj"] -->|"nos build,<br/>outside Unity"| dll["mylib.clj.dll<br/>(every instruction, already written)"]
+
+    dll -->|"Mono backend: magic-unity drops the<br/>generated workaround type,<br/>with Mono.Cecil"| mil["IL, packaged as it is"]
+    mil -->|"JIT on the device"| mach["machine code"]
+
+    dll -->|"IL2CPP backend: magic-unity adds<br/>the IL2CPP workarounds,<br/>with Mono.Cecil"| iil["rewritten IL"]
+    iil -->|"IL2CPP transpiles"| cpp["C++ source"]
+    cpp -->|"the platform's<br/>C++ compiler"| nat["native code"]
+
+    mach --> site["a dynamic call site runs on a cache type<br/>generated at build time ✅<br/>no IL is written to dispatch it"]
+    nat --> site
+```
+
+Emitting all IL statically also gives MAGIC direct control over the bytecode it produces, which helps where JVM and CLR semantics diverge, notably value types and generics. This is a different set of trade-offs from a DLR-based port, not a wholesale improvement: the DLR's runtime code generation buys flexibility, at the cost of the AOT compatibility MAGIC needs for iOS and IL2CPP.
+
+The Mono.Cecil step in the diagram belongs to `magic-unity`, and [Unity integration](./unity-integration.md) covers it along with the rest of the Unity workflow.
 
 ## Where each backend runs
 
-Unity has two scripting backends. The choice is per build target.
+Unity has two scripting backends, and the choice is per build target.
 
 | Platform | Backend | Why |
 |----------|---------|-----|
 | Desktop (PC/Mac) | Mono JIT or IL2CPP | No restriction; Mono is used for fast iteration |
-| Android | IL2CPP | 64-bit requirement; Mono has no ARM64 |
+| Android | IL2CPP | Google Play requires 64-bit and Unity's Mono backend has no ARM64 |
 | iOS | IL2CPP | Apple forbids runtime JIT (W^X) |
-| Consoles | IL2CPP | Similar AOT-only restrictions |
+| Consoles | IL2CPP | The console OS forbids runtime JIT (W^X), and Unity offers no other backend there |
 
-In practice IL2CPP is the production backend on every shipping platform; Mono JIT is only a desktop development convenience. MAGIC supports both.
+The reasons differ. On Android, nothing about the operating system is stopping you.
 
-## From source to device
+Phones run ARM CPUs, and the current ARM instruction set is 64-bit: `arm64-v8a`, also called ARM64 or AArch64. A binary is compiled for one instruction set or the other, so an Android app that contains native code ships a separate one per architecture. Google Play will not publish an app with native code unless an ARM64 build is among them, and Unity's Mono backend only builds 32-bit ARM on Android. That leaves exactly one backend for a shippable Android player, IL2CPP, and IL2CPP means AOT. Android itself JIT-compiles code all day and would happily run a program that generates its own. It is a store policy plus a gap in Unity's toolchain that rules it out, not the platform.
+
+iOS and the consoles are the other case. There the platform forbids runtime code generation outright, and no change of toolchain can help.
+
+So every mobile and console build goes through IL2CPP, and the choice only stays open on desktop, where Mono is the usual pick for fast iteration. MAGIC supports both.
+
+## Side by side with Clojure/JVM and ClojureCLR
+
+Clojure has many implementations (ClojureScript, ClojureDart, babashka, ...), and MAGIC is measured against two of them: Clojure on the JVM, the reference, and ClojureCLR, the other Clojure on the CLR. If you know either, the table below places MAGIC against them. The "Compiler runs" row is where everything above comes from.
+
+|                     | Clojure/JVM                  | ClojureCLR             | MAGIC                     |
+|---------------------|------------------------------|------------------------|---------------------------|
+| Runner              | `clj`                        | `cljr`                 | `nos`                     |
+| Compiler lives in   | `clojure.jar`                | `Clojure.dll`          | `magic-compiler/` + `mage/` |
+| Compiler written in | Java                         | C#                     | Clojure                   |
+| Compiler runs       | while the program runs       | while the program runs | ahead of time, during `nos build` |
+| Writes new code     | at run time, through ASM     | at run time, through the DLR and `Reflection.Emit` | at build time only, through `mage` and `Reflection.Emit` |
+| Data runtime        | `clojure/lang/*.java`        | `clojure/lang/*.cs`    | `clojure-runtime/`        |
+| Fast dispatch from  | HotSpot's JIT, for free      | the DLR                | `magic-runtime/`, by hand |
+| Output unit         | `my/ns__init.class` in a jar | `my.ns.clj.dll`        | `my.ns.clj.dll`           |
+
+The `clojure-runtime/` cell is not a rewrite: it is a fork of ClojureCLR's `clojure/lang/*.cs`, so the collections, keywords, vars and reader are the same code David Miller wrote. What the fork kept and dropped is in [the architecture](./architecture.md#the-runtime).
+
+A compiler written in Clojure has to compile itself, which is why the compiler's own compiled output is committed, in [the bootstrap](./bootstrap.md).
+
+## Where MAGIC came from
+
+MAGIC is eleven years old, and it was built for this exact problem before anything shipped on it.
+
+Ramsey Nasser started it in 2015 while working on [Arcadia](https://github.com/arcadia-unity/Arcadia), which put Clojure in the Unity editor on top of ClojureCLR. The blocker was the same one: ClojureCLR output did not survive Unity's export to its restricted targets, iOS among them. `mage` came first, in May 2015, and the compiler followed in July. Arcadia never switched over, so for years MAGIC was an alternative backend that worked and shipped nothing. That changed in 2021, when [Flybot](https://flybot.sg) needed Clojure game libraries running inside a shipping Unity game. Everything since is in the timeline below.
 
 ```mermaid
-flowchart TD
-    A["Clojure source (.cljc)"] -->|nos build| ASM["assemblies (MSIL):<br/>.clj.dll + .dll"]
-    B["C# source (.cs)"] -->|Unity compile| ASM
-    ASM --> MONO["Mono runtime<br/>(JIT at runtime)"]
-    ASM --> IL2CPP["IL2CPP<br/>(AOT at build time)"]
-    MONO --> MB["app binary<br/>(desktop dev)"]
-    IL2CPP --> IB["app binary<br/>(iOS, Android, consoles)"]
+timeline
+    title How MAGIC got here
+    2015 : Ramsey Nasser starts mage and the compiler, for Arcadia's export targets
+    2020 : Magic.Unity puts MAGIC inside a Unity project
+    2022 : Static and cached call sites replace plain runtime reflection : Magic.Unity drops its own compile path and becomes a runtime
+    2023 : The Mono.Cecil pre-build pass makes IL2CPP player builds work
+    2026 : Six repositories become this monorepo, with CI and an IL2CPP smoke suite : The Clojure 1.10 stdlib surface is completed, and magic.flags becomes the one config surface : Nostrand reads deps-clr.edn and magic.edn, so a CLR library carries no MAGIC-only files : Editor and player coexistence, shipped as two Unity packages : Compilation becomes deterministic, so CI byte-compares every committed binary
 ```
-
-The MSIL in a `.clj.dll` is not native code. Mono JIT-compiles it on the fly at runtime; IL2CPP transpiles it to C++ at build time. Because MAGIC's IL is fully static, both paths work. Before IL2CPP runs, `magic-unity` applies a Mono.Cecil pre-build step that adapts MAGIC's dispatch patterns for the AOT transpiler; see [magic-unity](../magic-unity/README.md) and [Unity integration](./unity-integration.md).
-
-## See also
-
-- [Writing cross-platform Clojure](./writing-cross-platform-clojure.md): the `.cljc` source patterns for code that runs on both the JVM and the CLR.
-- [magic-compiler](../magic-compiler/README.md): how the compiler itself works (analyzer, compilers, spells), with the Arcadia-era history that motivated it.
-- [Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md) and [Unity integration](./unity-integration.md): the build and consume workflows.

--- a/docs/writing-cross-platform-clojure.md
+++ b/docs/writing-cross-platform-clojure.md
@@ -1,60 +1,101 @@
-# Writing cross-platform Clojure (JVM + CLR)
+# Writing cross-platform Clojure
 
-MAGIC runs the same Clojure source the JVM does. A library that compiles for both a backend (JVM) and a Unity client (CLR via MAGIC) is written once, in `.cljc`, with the platform-specific parts gated behind reader conditionals.
+One `.cljc` library can serve the JVM, JS and the CLR.
 
-This guide is about the *source patterns*: reader conditionals, type hints, host interop, and what differs between the two runtimes. For the *build* side (`deps.edn`, `dotnet.clj`, CI) see [Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md). For why MAGIC exists at all see [Why MAGIC](./why-magic.md).
+They can therefore compile with both ClojureCLR and MAGIC. However, **the two CLR runtimes are not at the same Clojure version.**
 
-## File types and reader conditionals
+[ClojureCLR](https://github.com/clojure/clojure-clr) follows mainline Clojure releases closely, so it compiles more or less any codebase. MAGIC is at 1.10.
 
-| Extension | Loads on |
-|-----------|----------|
-| `.clj`  | JVM. Pure Clojure `.clj` (no host interop) also compiles under MAGIC. |
-| `.cljr` | CLR only. |
-| `.cljc` | Both. Needed once the file has `#?(:clj ... :cljr ...)` branches. |
+So a green `cljr` run might not be green on `nos`. A `parse-long` or an `update-vals` in shared code compiles under ClojureCLR and dies under MAGIC at compile time, on the first `nos build` or `nos test`:
 
-When more than one of those files exists for the same namespace, the CLR loader takes the first of `.cljr`, `.cljc`, `.clj`, so a `.cljc` shadows the JVM `.clj` beside it. MAGIC and ClojureCLR apply the same order.
-
-MAGIC code runs on exactly two platforms, so a conditional needs only `:clj` and `:cljr`; there is no third platform to fall back to, and `:default` is unnecessary.
-
-```clojure
-(ns my.lib.core
-  #?(:cljr (:import [System.Text.RegularExpressions Regex])))
-
-(defn round [n]
-  #?(:clj  (Math/round (double n))
-     :cljr (long (Math/Round (double n)))))
+```
+Unable to resolve symbol: parse-long (compiling ::)
 ```
 
-Reader conditionals are needed in three places: `require`/`import` (different class paths), type hints (CLR performance), and interop calls (different host methods). Everything else is plain portable Clojure. The `#?@` splice form injects a sequence into the surrounding form rather than a single value.
+That out of the way, porting to the CLR is mainly a matter of putting reader conditionals around host API differences. The conditionals themselves are covered by the [official guide](https://clojure.org/guides/reader_conditionals). For the build side see [declaring CLR dependencies](./clr-dependency-files.md) and [the `nos` CLI](./nos-cli.md).
 
-## Portable across ClojureCLR and MAGIC
+## Which extension loads where
 
-`:cljr` is the standard CLR reader conditional, not a MAGIC dialect: ClojureCLR (David Miller's .NET port) reads it too. So the same `.cljc` source compiles unchanged on both ClojureCLR and MAGIC, with no MAGIC-specific hacks, as long as it stays within the Clojure 1.10 stdlib (the surface MAGIC ships; see below). For example, [clojure/clr.test.check](https://github.com/clojure/clr.test.check) builds under MAGIC with zero changes from upstream.
+| Extension | Loads on |
+|---|---|
+| `.clj` | JVM. Pure Clojure with no host interop (also compiles under MAGIC/ClojureCLR for legacy reasons) |
+| `.cljr` | CLR only. Cannot contain reader conditionals. |
+| `.cljc` | Both. Needed as soon as the file has `#?(:clj ... :cljr ...)` reader conditionals. |
 
-## Type hints for CLR performance
+When one namespace resolves to more than one of them, both `cljr` and `nos` take the first of `.cljr`, `.cljc`, `.clj`, so a `.cljc` shadows the JVM `.clj` beside it.
 
-Type hints let MAGIC emit direct, unboxed calls instead of reflective dispatch. They are a CLR performance concern, so put them in the `:cljr` branch and keep the `:clj` side dynamic and test-friendly.
+That `.clj` at the end is why most CLR-only code in the wild is in the wrong file. `clr.data.json`, `clr.tools.reader` and most other `clr.*` ports are plain `.clj`, and `clr.tools.deps` mixes all three extensions in one tree. It is for legacy reasons: ClojureCLR is from 2009, `.cljc` arrived with Clojure 1.7 in 2015, and `.cljr` only landed in January 2023. Write new code the way the extensions read: `.cljr` when the namespace only ever runs on the CLR, `.cljc` when one file has to serve both platforms. But don't be surprised if you see CLR-only code in `.clj` in the wild.
 
-Value types on function arguments:
+## Coming from a library that already targets ClojureScript
+
+Quite a few `.cljc` libraries already serves the JVM and ClojureScript. And adding the CLR support is just adding one more `:cljr` reader conditional in theory. In practice we can make use of the `:default` reader conditional for host that behaves the same.
+
+The CLR and the JVM share the `clojure.lang.*` names, so their reader cond can be collapsed to `:default` branch while the `:cljs` handle the JS interop.
+
+That is why [`fun-map`](https://github.com/robertluo/fun-map) reads the way it does. Its branches are almost all `:cljs` against `:default`, and MAGIC takes the `:default` side without the file naming `:cljr` anywhere:
+
+```clojure
+#?(:cljs
+   (defprotocol IFunMap (-raw-seq [m]))
+   :default
+   (definterface IFunMap (rawSeq [])))
+
+(deftype CloseableValue [value close-fn]
+  #?(:cljs IDeref :default clojure.lang.IDeref)
+  #?(:cljs (-deref [_] value)
+     :default (deref [_] value))
+  Haltable
+  (halt! [_] (close-fn))
+  #?@(:clj  [java.io.Closeable   (close   [this] (halt! this))]
+      :cljr [System.IDisposable  (Dispose [this] (halt! this))]))
+```
+
+The last branch needs `#?@`, the splicing form, because `Closeable` and `IDisposable` share neither name nor method: one conditional has to contribute an interface and its implementation, and only `#?@` splices a sequence into the surrounding form.
+
+Two things about `:default` are worth knowing before you rely on it.
+
+**The first matching branch wins, so `:default` goes last.** Written the other way round it swallows the platform you meant to special-case, silently:
+
+```clojure
+;; read on the CLR
+#?(:cljr :from-cljr :default :from-default)   ; => :from-cljr
+#?(:default :from-default :cljr :from-cljr)   ; => :from-default, the :cljr branch is dead
+```
+
+**`:default` also means something else inside `catch`.** ClojureScript spells its catch-all `(catch :default e)`, so a portable catch ends up saying the word twice, once as a feature and once as the thing being caught:
+
+```clojure
+(catch #?(:cljs :default :default Exception) e ...)
+```
+
+Imports are where a real `:cljr` branch tends to survive, because each branch imports what its own code hints with. `fun-map` splits its import list for that reason: its JVM transient type hints the abstract base `ATransientMap`, while the other branch hints the `ITransientMap` interface, so the CLR side never names `ATransientMap` and does not import it.
+
+```clojure
+(:import #?(:clj  [clojure.lang IMapEntry IPersistentMap ITransientMap ATransientMap]
+            :cljr [clojure.lang IMapEntry IPersistentMap ITransientMap]))
+```
+
+Targeting only the JVM and the CLR, `:clj` and `:cljr` are the two branches you need and `:default` earns nothing.
+
+## Type hints are a CLR concern
+
+Hints let MAGIC emit a direct unboxed call instead of reflecting. They are also what `*strongly-typed-invokes*` builds on: the hints on a `defn` are what give it a typed `invokeTyped` surface at all ([compiler flags](./nos-cli.md#compiler-flags)). Keep them in the `:cljr` branch and leave the `:clj` side dynamic.
 
 ```clojure
 (defn scale
   #?(:clj  [factor n]
      :cljr [^double factor ^long n])
   (* factor n))
-```
 
-Record fields (the whole field vector is the conditional):
-
-```clojure
 (defrecord Point #?(:clj  [x y]
                     :cljr [^long x ^long y]))
 ```
 
-Reference types, for example a record defined in another namespace used as a parameter: import the class, then hint with it.
+For a reference type, `require` the namespace that defines it and then import the class. Both clauses are CLR-only here, since the hint is, and both go in `:cljr` branches:
 
 ```clojure
 (ns my.lib.geometry
+  #?(:cljr (:require [my.lib.shapes]))
   #?(:cljr (:import [my.lib.shapes Point])))
 
 (defn translate
@@ -63,32 +104,27 @@ Reference types, for example a record defined in another namespace used as a par
   (-> p (update :x + dx) (update :y + dy)))
 ```
 
-A type hint that cannot resolve is a hard error, so a typo or missing import fails fast.
+The `require` is not optional and its position is not either. `:import` resolves a name against the assemblies already loaded in the process, never against the disk, so the namespace defining `Point` has to be loaded first or the compile fails with `Could not find type my.lib.shapes.Point during import`. Clauses run in written order, which is what makes `:require` first sufficient. It is the same rule a precompiled C# assembly runs into, in its harder form, where nothing loads the assembly for you at all ([native assemblies](./native-assemblies.md)).
 
-Limitations:
+A hint that cannot resolve is a hard error rather than a warning, so a typo or a missing import fails at compile time. Two hints to avoid: a collection's element type, which has no hint syntax at all, and a map's concrete class, which flips between `PersistentArrayMap` and `PersistentHashMap` with size. Hint the interface `clojure.lang.IPersistentMap` instead.
 
-- Collections cannot be hinted with an element type (no "vector of `Point`").
-- Maps are not worth hinting; the concrete class varies (`PersistentArrayMap`, `PersistentHashMap`, ...).
+## Host APIs that differ
 
-## Records, types, and protocols
-
-`defrecord`, `deftype`, `defprotocol`, `reify`, `proxy`, and multimethods work exactly as on the JVM, with no reader conditional. Record `=` is structural, so use `defrecord` when you want value equality; a `deftype` has reference identity. Mutable `deftype` fields (`^:unsynchronized-mutable` + `set!`) work too.
-
-## Host APIs that genuinely differ
-
-These reflect real JVM-versus-CLR API differences and stay in the source forever (unlike the workaround above). Keep the reader conditional.
+Examples of interops you might need:
 
 | Need | `:clj` | `:cljr` |
-|------|--------|---------|
+|---|---|---|
 | Class name of a value | `(.getName (class x))` | `(.FullName (class x))` |
-| Namespace name | `(.getName *ns*)` | `Namespace.Name` (not `.FullName`) |
-| Writer type hint | `^java.io.Writer` | `^System.IO.TextWriter` |
+| Namespace name | `(.getName *ns*)` | `(.Name *ns*)`, not `.FullName` |
+| Writer hint | `^java.io.Writer` | `^System.IO.TextWriter` |
 | Writer method | `(.write w s)` | `(.Write w s)` |
-| Regex type hint | `^java.util.regex.Pattern` | `^System.Text.RegularExpressions.Regex` |
+| Regex hint | `^java.util.regex.Pattern` | `^System.Text.RegularExpressions.Regex` |
 | Round a double | `(Math/round ...)` | `(Math/Round ...)` |
-| Wall-clock millis | `(System/currentTimeMillis)` | `(Environment/TickCount)` |
+| Epoch milliseconds | `(System/currentTimeMillis)` | `(.ToUnixTimeMilliseconds (DateTimeOffset/UtcNow))` |
 
-`print-method` is the everyday case:
+`Environment/TickCount` is not the CLR answer for the last row, however close it looks. It counts milliseconds since the machine booted, in an `Int32` that wraps roughly every 25 days, so it is a stopwatch and not a clock. Reach for `System.Diagnostics.Stopwatch` when you want elapsed time.
+
+`print-method` is the case you might meet often too:
 
 ```clojure
 #?(:clj  (defmethod print-method Square [^Square s ^java.io.Writer w]
@@ -97,20 +133,17 @@ These reflect real JVM-versus-CLR API differences and stay in the source forever
            (.Write w (str "#Square " (:side s)))))
 ```
 
-Portable without a conditional:
+`(catch Exception e ...)` and `(thrown? Exception ...)` need no conditional even though they look like they should: bare `Exception` resolves at compile time on both runtimes.
 
-- `(catch Exception e ...)` and `(thrown? Exception ...)`: bare `Exception` resolves at compile time on both runtimes.
-- Prefer a stdlib fn over a hand-copied `:cljr` variant. MAGIC's stdlib already uses the CLR-correct host calls (for example `clojure.datafy/datafy`), so call it rather than copying it to swap `.getName` for `.FullName`.
+A `hash`-derived identity carries across runtimes: MAGIC aligned String and map `hasheq` with the JVM, so `(hash "hello")` is 1715862179 on both. Only the formatting call differs, `Integer/toHexString` on the JVM against `(.ToString n "x")` on the CLR, and the lowercase `x` is not optional. `"X"` gives you `FF` where the JVM gives `ff`.
 
-A `hash`-derived identity needs care. A value computed from `hash` (a hex id, say) is self-consistent within one runtime, and MAGIC aligned String and map `hasheq` with the JVM so the values match across runtimes too. But if you persist such an id on one runtime and compare it on the other, format the hex the same way: `Integer/toHexString` on the JVM, `(.ToString n "x")` with a lowercase `x` on the CLR.
+## The stdlib stops at Clojure 1.10
 
-## Standard library: MAGIC is at Clojure 1.10
+MAGIC ships the Clojure 1.10 surface, right up to its last additions: `ex-message`, `ex-cause`, `tap>`, `read+string`, the 1.10-shape `Throwable->map`, and `prepl` / `io-prepl` / `remote-prepl`.
 
-MAGIC's stdlib is at Clojure 1.10 parity. The full marked-1.10 surface is on the CLR, including `ex-message` / `ex-cause`, `tap>`, `read+string`, the 1.10-shape `Throwable->map`, and `prepl` / `io-prepl` / `remote-prepl`. Most of `clojure.core`, `clojure.string`, `clojure.set`, `clojure.spec.alpha`, protocols, records, and multimethods work without conditionals.
+It stops there. Everything from 1.11 onward is absent: `update-vals`, `parse-long`, `random-uuid` and the rest of the newer core fns, the `clojure.math` namespace, and the 1.11 keyword-arguments calling convention. This is a boundary, not a short list of gaps.
 
-MAGIC targets Clojure 1.10. Mainline Clojure is now at 1.12, so everything added in 1.11 and 1.12 is unavailable: new `clojure.core` fns (`update-vals`, `parse-long`, `random-uuid`, ...), the `clojure.math` namespace, and a new keyword-arguments calling convention, among others. This is a real boundary, not a couple of functions.
-
-An individual missing core fn can be shimmed under `:cljr`:
+A missing core fn can be shimmed under `:cljr`:
 
 ```clojure
 #?(:cljr (defn update-vals [m f]
@@ -118,25 +151,42 @@ An individual missing core fn can be shimmed under `:cljr`:
             (reduce-kv (fn [acc k v] (assoc! acc k (f v))) (transient {}) m))))
 ```
 
-Changes baked into the calling convention or the compiler (the 1.11 trailing-map keyword arguments, for one) cannot be shimmed. Keep cross-platform code on 1.10 idioms, and treat "added in 1.11" in the Clojure changelog as "not in MAGIC".
+A change baked into the calling convention cannot be. Read "added in 1.11" in the Clojure changelog as "not in MAGIC", and stay on 1.10 idioms in shared code.
 
 ## Linting
 
-clj-kondo runs on the JVM, so it cannot resolve two kinds of symbol in a `.cljc` file and flags them as lint noise, not real errors:
+clj-kondo models JVM Clojure and has no `:cljr` feature. Asking for one does not degrade, it fails:
 
-1. Symbols inside a `:cljr` branch (`System.*` types, CLR-only methods).
-2. Bare host symbols used unconditionally, notably `Exception` in `(catch Exception e)` / `(thrown? Exception ...)`.
+```
+$ clj-kondo --lint x.cljc          # with {:cljc {:features #{:clj :cljr}}}
+x.cljc:0:0: error: Can't parse x.cljc, No matching clause: :cljr
+```
 
-Default clj-kondo to the `:clj` feature set so CLR-only branches grey out instead of erroring:
+Which leaves the two extensions in opposite positions, and each wants a different fix.
+
+**`.cljc` is analysed under `:clj` and `:cljs`.** A `:cljr` branch matches neither, so it is skipped and reports nothing. The noise comes from the `:cljs` pass instead: unconditional code that ClojureScript cannot resolve, most often `(catch Exception e ...)`, and any host type the `:clj` branch imported. If the library has no ClojureScript target, drop that pass:
 
 ```clojure
 ;; .clj-kondo/config.edn
 {:cljc {:features #{:clj}}}
 ```
 
-## See also
+If it does target ClojureScript, keep both features and put the offending form behind a conditional.
 
-- [Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md): the build side (`deps.edn`, `dotnet.clj`, CI, RCT on the CLR).
-- [Unity integration](./unity-integration.md): compiling `.clj.dll` and loading them in Unity.
-- [Why MAGIC](./why-magic.md): why the CLR needs a dedicated static compiler.
-- [`magic-compiler/src/magic/flags.clj`](../magic-compiler/src/magic/flags.clj): the compiler flags. Production builds set `*direct-linking*` and `*strongly-typed-invokes*`.
+**`.cljr` is analysed as ordinary Clojure**, which is better (real typos get caught) and noisier. Two CLR-isms have no JVM equivalent for clj-kondo to resolve: a static class used without an import reads as a namespace, and the CLR-only `clojure.core` vars are simply unknown.
+
+```
+load_dll.cljr:9:22: warning: Unresolved namespace Environment. Are you missing a require?
+load_dll.cljr:15:6:  error:   Unresolved symbol: assembly-load-from
+```
+
+Silence those per namespace rather than globally, so a genuine typo elsewhere still fails:
+
+```clojure
+{:config-in-ns
+ {my-lib.load-dll
+  {:linters {:unresolved-namespace {:exclude [Environment]}
+             :unresolved-symbol    {:exclude [assembly-load-from]}}}}}
+```
+
+One asymmetry to know: `clj-kondo --lint src` over a directory skips `.cljr` entirely. Only naming the file lints it, which is what an editor does, so a `.cljr` file only ever gets linted while it is open in front of you.

--- a/mage/README.md
+++ b/mage/README.md
@@ -1,31 +1,35 @@
 MAGE
 ====
-Symbolic MSIL bytecode generation for ClojureCLR.
+Symbolic MSIL bytecode generation for Clojure on the CLR. Bundled in the [flybot-sg/magic](https://github.com/flybot-sg/magic) monorepo as the emitter [MAGIC](../magic-compiler) compiles into.
 
 Quick Example
 -------------
 ```clojure
 (require '[mage.core :as il])
+(import '[System.Reflection TypeAttributes])
 
 (il/emit!
   (il/assembly "Example"
     [(il/module "Example.dll"
-      [(il/type "ExampleType"
+      [(il/type "ExampleType" TypeAttributes/Public [] System.Object nil
         [(il/method
           "AddIntegers"
           Int32 [Int32 Int32]
           [(il/ldarg-1)
            (il/ldarg-2)
            (il/add)
-           (il/ret)])])])]))
+           (il/ret)])]
+        [])])]))
 
 (.AddIntegers (ExampleType.) 5 6)
 ;; 11
 ```
 
+`il/type` is the one constructor that has to be spelled out in full: its shorter arities are currently unreachable, so pass attributes, interfaces, supertype, generic parameters, body and custom attributes every time.
+
 Overview
 --------
-MAGE wraps the entire CLR [`System.Reflection.Emit` namespace](https://msdn.microsoft.com/en-us/library/system.reflection.emit(v=vs.110).aspx) in a [gamma](https://github.com/kovasb/gamma)-style symbolic compiler. The goal is a functional, composable, data- and REPL-driven bytecode emission framework for the CLR. A tree of symbolic [MSIL bytecode](https://en.wikipedia.org/wiki/Common_Intermediate_Language) is built as Clojure data, and passed to an `emit!` function to generate usable MSIL bytecode on disk as a DLL file or directly in memory as C# types.
+MAGE wraps the entire CLR [`System.Reflection.Emit` namespace](https://msdn.microsoft.com/en-us/library/system.reflection.emit(v=vs.110).aspx) in a [gamma](https://github.com/kovasb/gamma)-style symbolic compiler. The goal is a functional, composable, data- and REPL-driven bytecode emission framework for the CLR. A tree of symbolic [MSIL bytecode](https://en.wikipedia.org/wiki/Common_Intermediate_Language) is built as Clojure data, and passed to an `emit!` function that turns it into runnable CLR types in memory. Writing a DLL to disk is the caller's job, on top of that.
 
 ### Symbolic Bytecode
 At the heart of MAGE is the symbolic representation of MSIL. Representing bytecode as persistent data allows it to be manipulated functionally before anything is generated. MAGE provides constructor functions that produce the maps that the emission logic expects.
@@ -99,58 +103,33 @@ MSIL uses labels and branching to implement loops and conditionals. This is an i
 ```
 
 #### Methods, Types, Modules, and Assemblies
-Opcodes cannot exist on their own. They must be part of the body of a method, which must be part of a type, which must be in a module, which must be in an assembly.
+Opcodes cannot exist on their own. They must be part of the body of a method, which must be part of a type, which must be in a module, which must be in an assembly. Each level is a map that carries the next one under `::body`, so the assembly from the Quick Example is this value:
 
 ```clojure
-(il/assembly "Example"       ;; [{:mage.core/begin :assembly,
-  (il/module "Example.dll"   ;;   :mage.core/argument
-    (il/type "ExampleType"   ;;   {:mage.core/name #<AssemblyName Example>,
-      (il/method             ;;    :mage.core/access RunAndSave}}
-        "AddIntegers"        ;;  [{:mage.core/begin :module,
-        Int32 [Int32 Int32]  ;;    :mage.core/argument {:mage.core/name "Example.dll"}}
-        [(il/ldarg-1)        ;;   [{:mage.core/begin :type,
-         (il/ldarg-2)        ;;     :mage.core/argument
-         (il/add)]))))       ;;     {:mage.core/name "ExampleType",
-                             ;;      :mage.core/attributes Public,
-                             ;;      :mage.core/interfaces [],
-                             ;;      :mage.core/super System.Object}}
-                             ;;    [{:mage.core/begin :method,
-                             ;;      :mage.core/argument
-                             ;;      {:mage.core/name "AddIntegers",
-                             ;;       :mage.core/attributes Public,
-                             ;;       :mage.core/return-type System.Int32,
-                             ;;       :mage.core/parameter-types [System.Int32, System.Int32]}}
-                             ;;     [{:mage.core/opcode ldarg.1}
-                             ;;      {:mage.core/opcode ldarg.2}
-                             ;;      {:mage.core/opcode add}]
-                             ;;     {:mage.core/end :method}]
-                             ;;    {:mage.core/end :type}]
-                             ;;   {:mage.core/end :module}]
-                             ;;  {:mage.core/end :assembly}]
+{:mage.core/assembly "Example"
+ :mage.core/access   Run
+ :mage.core/body
+ [{:mage.core/module "Example.dll"
+   :mage.core/body
+   [{:mage.core/type       "ExampleType"
+     :mage.core/attributes AutoLayout, AnsiClass, Class, Public
+     :mage.core/interfaces []
+     :mage.core/super      System.Object
+     :mage.core/body
+     [{:mage.core/method      "AddIntegers"
+       :mage.core/return-type System.Int32
+       :mage.core/parameters  [{:mage.core/parameter System.Int32 ...}
+                               {:mage.core/parameter System.Int32 ...}]
+       :mage.core/body
+       [{:mage.core/opcode ldarg.1}
+        {:mage.core/opcode ldarg.2}
+        {:mage.core/opcode add}
+        {:mage.core/opcode ret}]}]}]}]}
 ```
 
 ### Emission
 
-`emit!` will flatten the given tree and emit MSIL bytecode to both disk as a DLL file and into memory. The resulting DLL file can be found at the CLR execution root directory, and the generated types can be used right away.
-
-```clojure
-(il/emit!
-  (il/assembly "Example"
-    (il/module "Example.dll"
-      (il/type "ExampleType"
-        (il/method
-          "AddIntegers"
-          Int32 [Int32 Int32]
-          [(il/ldarg-1)
-           (il/ldarg-2)
-           (il/sub)
-           (il/ret)])))))
-
-(.AddIntegers (ExampleType.) 5 6)
-;; 11
-```
-
-Future versions of MAGE will have a more nuanced `emit!` with better control over where the bytecode goes.
+`emit!` flattens the tree and builds it through `System.Reflection.Emit`, so the generated types are usable as soon as the call returns. It builds in memory and writes no file: `il/assembly` defaults to `AssemblyBuilderAccess/Run`, and a caller that wants a DLL on disk asks for `RunAndSave` and saves the builder itself. That is what MAGIC does, in [`magic.emission`](../magic-compiler/src/magic/emission.clj).
 
 Rationale and History
 ---------------------
@@ -166,12 +145,7 @@ MAGE stands for Morgan And Grand Emitter. It is named after the [Morgan Avenue a
 
 Legal
 -----
-Copyright © 2015 Ramsey Nasser
+Copyright © 2015-2023 Ramsey Nasser and contributors.
+Copyright © 2026 Flybot Pte. Ltd.
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-
-```
-http://www.apache.org/licenses/LICENSE-2.0
-```
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+Licensed under the Apache License, Version 2.0.

--- a/magic-compiler/README.md
+++ b/magic-compiler/README.md
@@ -13,7 +13,7 @@ The compiler is feature-complete against Clojure 1.10 and used in production (Fl
 MAGIC is a compiler for Clojure written in Clojure targeting the Common Language Runtime. Its goals are to:
 
 1. Take full advantage of the CLR's features to produce better byte code
-2. Leverage Clojure's functional programming and data structures to be more tunable, composeable, and maintainable
+2. Use Clojure's functional programming and data structures to be more tunable, composeable, and maintainable
 
 ## Building and testing
 
@@ -90,7 +90,7 @@ A *spell* is one such map rewrite packaged as a `(fn [compilers] compilers')`, a
 
 ## Configuration
 
-Every knob that controls compilation is a dynamic var in [`src/magic/flags.clj`](src/magic/flags.clj), the single configuration surface: you `binding` the flags, the compiler reads them.
+Every option that controls compilation is a dynamic var in [`src/magic/flags.clj`](src/magic/flags.clj), the single configuration surface: you `binding` the flags, the compiler reads them.
 
 Clients bind the optimization vars to control the codegen their build ships, chiefly `*direct-linking*` and `*strongly-typed-invokes*`. Compiler developers also bind the build-shaping options when needed: `*sparse-case*` for runtime-stable hashing (the `bb bootstrap :spells '[magic.spells.sparse-case/sparse-case]'` pass), plus `*legacy-dynamic-callsites*` and `*elide-meta*`. Spells (`*lift-vars*`, `*lift-keywords*`, `*sparse-case*`) are flags too, so toggling one is the same idiom as any other:
 
@@ -110,6 +110,7 @@ MAGIC stands for "Morgan And Grand Iron Clojure" (originally "Morgan And Grand I
 
 ## Legal
 
-Copyright © 2015-2020 Ramsey Nasser and contributors.
+Copyright © 2015-2023 Ramsey Nasser and contributors.
+Copyright © 2026 Flybot Pte. Ltd.
 
 Licensed under the Apache License, Version 2.0.

--- a/magic-runtime/README.md
+++ b/magic-runtime/README.md
@@ -2,26 +2,31 @@
 
 The C# runtime that MAGIC-compiled assemblies call into for dynamic dispatch.
 
+It is a separate assembly from [clojure-runtime](../clojure-runtime) by design: keeping new functionality out of the ClojureCLR fork makes ingesting upstream updates easier, so anything new MAGIC needs lands here instead.
+
 Two projects:
 
-- `Magic.Runtime/` is the runtime proper. Compiles to `Magic.Runtime.dll`, which compiled `.clj.dll`s reference by name. `Dispatch` resolves zero-arity members, instance methods, static methods, and constructors at call time when MAGIC could not statically bind them. `Binder` and `Emission` back the call-site cache that the compiler emits inline. `Runtime` exposes entry points used at host load time (`InvokeInitType`, `TryLoadInitType`, `FindType`).
+- `Magic.Runtime/` is the runtime proper. Compiles to `Magic.Runtime.dll`, which compiled `.clj.dll`s reference by name. `Dispatch` resolves zero-arity members, instance methods, static methods, and constructors at call time when MAGIC could not statically bind them. `Binder` and `Emission` back the call-site cache that the compiler emits inline. `Runtime` exposes the entry points compiled code and the host call into: `InvokeInitType`, `TryLoadInitType`, `FindType`, and `FindTypeOrThrow`, which a deferred `:import` emits so an unresolvable type fails at load with a hint naming the DLLs on the load path that match its namespace.
 - `Magic.Runtime.Callsites/` is a build-time code generator (a standalone .NET program, not loaded at runtime). It reads the `*.mustache` templates in that directory and writes per-arity call-site, cache, and delegate-helper classes into `Magic.Runtime/Generated/*.g.cs` for arities 1 through 20. The compiler emits IL that targets those generated types directly, so editing a template requires regenerating the `.g.cs` files before the runtime can be rebuilt.
 
 ## When to rebuild
 
 | You changed | Run |
 |---|---|
-| `Magic.Runtime/**/*.cs` | `bb dev-runtime` |
+| `Magic.Runtime/**/*.cs` | `bb build-runtime` |
 | `Magic.Runtime.Callsites/*.mustache` | `bb dev-callsites` (regenerates `.g.cs` first, then rebuilds the runtime) |
 
-See the top-level [README](../README.md) for the full development workflow.
+See [the development guide](../docs/development.md) for the full workflow.
 
 `bb check-drift` fails CI if `.g.cs` files are stale relative to the mustache sources, so regenerated output must be committed alongside template edits.
 
 ## Loading
 
-Compiled `.clj.dll`s reference `Magic.Runtime.dll` by name. New runtime bodies are picked up at load time, no compiler rebootstrap needed. This is why `bb dev-runtime` is the fast iteration loop (seconds) and `bb dev-compiler` is the slow one (minutes).
+Compiled `.clj.dll`s reference `Magic.Runtime.dll` by name. New runtime bodies are picked up at load time, no compiler rebootstrap needed. This is why `bb build-runtime` is the fast iteration loop (seconds) and `bb dev-compiler` is the slow one (minutes).
 
 ## Legal
 
-Copyright (c) 2017-2023 Ramsey Nasser and contributors. Licensed under the Apache License, Version 2.0.
+Copyright © 2017-2023 Ramsey Nasser and contributors.
+Copyright © 2026 Flybot Pte. Ltd.
+
+Licensed under the Apache License, Version 2.0.

--- a/magic-unity-dual/README.md
+++ b/magic-unity-dual/README.md
@@ -1,32 +1,24 @@
-MAGIC Unity Integration
-=======================
+# MAGIC Unity Integration
 
 [Unity](https://unity.com/) integration for the MAGIC compiler.
 
-This UPM package ships the Clojure runtime DLLs that Unity loads at play time, plus the Editor-side preprocessors that rewrite MAGIC's IL during an IL2CPP build (iOS, Android, consoles). It does not compile Clojure; that step runs outside Unity via `nos dotnet/build` (see [Nostrand](../nostrand)).
+This UPM package ships the Clojure runtime DLLs that Unity loads at play time, plus the Editor-side preprocessors that rewrite MAGIC's IL during an IL2CPP build (iOS, Android, consoles). It does not compile Clojure; that step runs outside Unity with `nos build` (see [Nostrand](../nostrand)).
+
+For the consumer-side setup, adding the package and compiling into a project, see [Unity integration](../docs/unity-integration.md). This page is what the package contains and how it behaves.
 
 ## Install
 
-Consume as a UPM package via git URL in `Packages/manifest.json`, pinned to a tag from the [releases page](https://github.com/flybot-sg/magic/releases). Pick the variant that matches how your Editor runs Clojure (see [Package variants](#package-variants)):
+Consume as a UPM package via git URL in `Packages/manifest.json`, pinned to a tag from the [releases page](https://github.com/flybot-sg/magic/releases):
 
 ```
-// Default: MAGIC everywhere, including the Editor's Play mode. For projects
-// with no stock ClojureCLR.
 "sg.flybot.magic.unity": "https://github.com/flybot-sg/magic.git?path=magic-unity#<tag>"
 ```
 
-```
-// Dual: stock ClojureCLR in the Editor, MAGIC in player builds. The runtime
-// DLLs are excluded from the Editor, so there is no console noise and no probe
-// clash. For projects that keep ClojureCLR for Editor / REPL work.
-"sg.flybot.magic.unity.dual": "https://github.com/flybot-sg/magic.git?path=magic-unity-dual#<tag>"
-```
-
-Install exactly one variant. See [magic-unity-smoke](../unity-examples/magic-unity-smoke) for a working IL2CPP regression project that uses this integration.
+Install exactly one variant; picking between this default and `.dual` is [Package variants](#package-variants) below. The full consumer setup, `deps.edn` / `magic.edn` and the compile step, is [Unity integration](../docs/unity-integration.md), and [magic-unity-smoke](../unity-examples/magic-unity-smoke) is a working IL2CPP project using this integration.
 
 ## What the package ships
 
-- `Runtime/Infrastructure/Export/` - prebuilt Clojure runtime: `Clojure.dll`, `Magic.Runtime.dll`, and the full stdlib as `*.clj.dll` (e.g. `clojure.core.clj.dll`, `clojure.pprint.clj.dll`, ...). Unity loads these as regular .NET assemblies at play time.
+- `Runtime/Infrastructure/Export/` - prebuilt Clojure runtime: `Clojure.dll`, `Magic.Runtime.dll`, and 37 stdlib `*.clj.dll` (`clojure.core.clj.dll`, `clojure.pprint.clj.dll`, ...). Unity loads these as regular .NET assemblies at play time. The compiler's own DLLs are not among them; the package ships no compiler.
 - `Runtime/Magic.Unity.cs` - the `Magic.Unity.Clojure` API (Boot/Require/GetVar) that C# scripts call to drive the Clojure runtime. Sets the platform-appropriate code-load order (`InitType` only on IL2CPP, `InitType` + `FileSystem` in the Editor).
 - `Editor/MagicPreprocessor.cs` - an `IPreprocessBuildWithReport` hook that runs on every build and drives the IL2CPP-specific rewrites below.
 - `Editor/IL2CPPWorkarounds.cs` - walks each candidate assembly with Mono.Cecil and applies `EliminateUnreachableInstructions` (removes dead IL the AOT linker chokes on) and `GenerateGenericWorkaroundMethods` (synthesises reachable instantiations of generic delegate helpers so IL2CPP's generic-sharing pass can find them).
@@ -34,10 +26,10 @@ Install exactly one variant. See [magic-unity-smoke](../unity-examples/magic-uni
 
 ## How it works
 
-1. You compile your own Clojure namespaces to `.clj.dll` outside Unity via `nos dotnet/build`, writing them into `Assets/Plugins/Magic/` (see [magic-unity-smoke/dotnet.clj](../unity-examples/magic-unity-smoke/dotnet.clj) for the canonical task definition). The package does not include a compiler.
+1. You compile your own Clojure namespaces outside Unity with `nos build`, writing them into `Assets/Plugins/Magic/`. A `.clj` source becomes `foo.clj.dll`, a `.cljc` becomes `foo.cljc.dll` and a `.cljr` becomes `foo.cljr.dll`; the Editor hooks below match all three. A project needing build steps the built-in task does not cover writes its own instead, as [magic-unity-smoke](../unity-examples/magic-unity-smoke/dotnet.clj) does.
 2. Unity opens the project. The prebuilt runtime + stdlib from `Runtime/Infrastructure/Export/` and your own `.clj.dll`s are both loaded as plain .NET assemblies. `Magic.Unity.Clojure.Boot()` initialises the runtime; `Require` / `GetVar` let C# scripts call into Clojure.
 3. On every build, `MagicPreprocessor` runs first. When the build target uses IL2CPP, it rewrites the `.clj.dll` bodies in place so the IL2CPP transpiler can consume them (and writes `link.xml` entries); on a Mono build the preprocessor only sweeps any leftover IL2CPP-only workarounds from a previous build. The runtime DLLs are loaded the same way under either backend.
-4. Coexistence with stock ClojureCLR: if a strong-named `Clojure.dll` is found under `Assets` (projects that keep ClojureCLR for Editor work and MAGIC for shipped builds), every MAGIC-compiled `.clj.dll` is imported with Editor loading off, because the stock runtime probe-loads `clojure.core.clj` at init and a MAGIC DLL answering that probe fails to load. With this default variant the runtime ships Editor-loadable, so on an immutable (PackageCache) install the Editor logs `Assembly '...clj.dll' will not be loaded due to errors: Assembly is incompatible with the editor` for the package's `Export` DLLs on every domain reload. These lines are benign (Unity reporting the intended exclusion, not a failure), and player builds are unaffected. To silence them, use the [`.dual` variant](#package-variants), which ships the runtime excluded from the Editor by construction.
+4. Coexistence with ClojureCLR: if a strong-named `Clojure.dll` is found under `Assets` (projects that keep ClojureCLR for Editor work and MAGIC for shipped builds), every MAGIC-compiled assembly is imported with Editor loading off. The reason is assembly enumeration order: ClojureCLR resolves a namespace by scanning the loaded assemblies for a `<ns>__Init` type and taking the first match, so a MAGIC `.clj.dll` sitting in the Editor domain can answer for a `clojure.*` namespace, and its answer throws. Keeping them out of the domain, rather than off the filesystem, is what fixes it. With this default variant the runtime ships Editor-loadable, so on an immutable (PackageCache) install the Editor logs `Assembly '...clj.dll' will not be loaded due to errors: Assembly is incompatible with the editor` for the package's `Export` DLLs on every domain reload. These lines are benign (Unity reporting the intended exclusion, not a failure), and player builds are unaffected. To silence them, use the [`.dual` variant](#package-variants), which ships the runtime excluded from the Editor by construction.
 
 ## Package variants
 
@@ -46,11 +38,11 @@ The package is shipped in two variants. They are identical except for one thing:
 | | `sg.flybot.magic.unity` (default) | `sg.flybot.magic.unity.dual` |
 |---|---|---|
 | Runtime in the Editor | yes (loadable) | no (`!UNITY_EDITOR`) |
-| MAGIC in Editor Play mode | works | not available (use stock ClojureCLR) |
-| Stock ClojureCLR alongside | probe clash, handled by the coexistence guard, with benign console noise | no clash, no noise (runtime is simply absent from the Editor) |
+| MAGIC in Editor Play mode | works | not available (use ClojureCLR) |
+| ClojureCLR alongside | probe clash, handled by the coexistence guard, with benign console noise | no clash, no noise (runtime is simply absent from the Editor) |
 | Player builds (Mono / IL2CPP) | identical | identical |
 
-Choose the **default** if your project runs MAGIC in the Editor (Play mode, edit-mode tooling) and has no stock ClojureCLR. Choose **`.dual`** if your Editor runs stock ClojureCLR (REPL / hot-reload) and MAGIC only ships in player builds: the runtime is excluded from the Editor by the define constraint, so Unity never attempts to load it there and prints no narration.
+Choose the **default** if your project runs MAGIC in the Editor (Play mode, edit-mode tooling) and has no ClojureCLR. Choose **`.dual`** if your Editor runs ClojureCLR (REPL / hot-reload) and MAGIC only ships in player builds: the runtime is excluded from the Editor by the define constraint, so Unity never attempts to load it there and prints no narration.
 
 `magic-unity-dual/` is generated from `magic-unity/` by `bb gen-unity-dual` (the DLLs are byte-identical copies; only the 37 runtime `.meta`s and the package name differ) and is kept in sync by `bb check-drift`. The in-repo coexistence repro that validates both variants is `magic-unity-coexist/` (`bb coexist-noise` for the dual variant, `bb coexist-noise magic-only` to reproduce the noise).
 
@@ -65,4 +57,7 @@ Choose the **default** if your project runs MAGIC in the Editor (Play mode, edit
 
 ## Legal
 
-Copyright © 2020 Ramsey Nasser and contributors. Licensed under the Apache License, Version 2.0.
+Copyright © 2020-2023 Ramsey Nasser and contributors.
+Copyright © 2026 Flybot Pte. Ltd.
+
+Licensed under the Apache License, Version 2.0.

--- a/magic-unity/README.md
+++ b/magic-unity/README.md
@@ -1,32 +1,24 @@
-MAGIC Unity Integration
-=======================
+# MAGIC Unity Integration
 
 [Unity](https://unity.com/) integration for the MAGIC compiler.
 
-This UPM package ships the Clojure runtime DLLs that Unity loads at play time, plus the Editor-side preprocessors that rewrite MAGIC's IL during an IL2CPP build (iOS, Android, consoles). It does not compile Clojure; that step runs outside Unity via `nos dotnet/build` (see [Nostrand](../nostrand)).
+This UPM package ships the Clojure runtime DLLs that Unity loads at play time, plus the Editor-side preprocessors that rewrite MAGIC's IL during an IL2CPP build (iOS, Android, consoles). It does not compile Clojure; that step runs outside Unity with `nos build` (see [Nostrand](../nostrand)).
+
+For the consumer-side setup, adding the package and compiling into a project, see [Unity integration](../docs/unity-integration.md). This page is what the package contains and how it behaves.
 
 ## Install
 
-Consume as a UPM package via git URL in `Packages/manifest.json`, pinned to a tag from the [releases page](https://github.com/flybot-sg/magic/releases). Pick the variant that matches how your Editor runs Clojure (see [Package variants](#package-variants)):
+Consume as a UPM package via git URL in `Packages/manifest.json`, pinned to a tag from the [releases page](https://github.com/flybot-sg/magic/releases):
 
 ```
-// Default: MAGIC everywhere, including the Editor's Play mode. For projects
-// with no stock ClojureCLR.
 "sg.flybot.magic.unity": "https://github.com/flybot-sg/magic.git?path=magic-unity#<tag>"
 ```
 
-```
-// Dual: stock ClojureCLR in the Editor, MAGIC in player builds. The runtime
-// DLLs are excluded from the Editor, so there is no console noise and no probe
-// clash. For projects that keep ClojureCLR for Editor / REPL work.
-"sg.flybot.magic.unity.dual": "https://github.com/flybot-sg/magic.git?path=magic-unity-dual#<tag>"
-```
-
-Install exactly one variant. See [magic-unity-smoke](../unity-examples/magic-unity-smoke) for a working IL2CPP regression project that uses this integration.
+Install exactly one variant; picking between this default and `.dual` is [Package variants](#package-variants) below. The full consumer setup, `deps.edn` / `magic.edn` and the compile step, is [Unity integration](../docs/unity-integration.md), and [magic-unity-smoke](../unity-examples/magic-unity-smoke) is a working IL2CPP project using this integration.
 
 ## What the package ships
 
-- `Runtime/Infrastructure/Export/` - prebuilt Clojure runtime: `Clojure.dll`, `Magic.Runtime.dll`, and the full stdlib as `*.clj.dll` (e.g. `clojure.core.clj.dll`, `clojure.pprint.clj.dll`, ...). Unity loads these as regular .NET assemblies at play time.
+- `Runtime/Infrastructure/Export/` - prebuilt Clojure runtime: `Clojure.dll`, `Magic.Runtime.dll`, and 37 stdlib `*.clj.dll` (`clojure.core.clj.dll`, `clojure.pprint.clj.dll`, ...). Unity loads these as regular .NET assemblies at play time. The compiler's own DLLs are not among them; the package ships no compiler.
 - `Runtime/Magic.Unity.cs` - the `Magic.Unity.Clojure` API (Boot/Require/GetVar) that C# scripts call to drive the Clojure runtime. Sets the platform-appropriate code-load order (`InitType` only on IL2CPP, `InitType` + `FileSystem` in the Editor).
 - `Editor/MagicPreprocessor.cs` - an `IPreprocessBuildWithReport` hook that runs on every build and drives the IL2CPP-specific rewrites below.
 - `Editor/IL2CPPWorkarounds.cs` - walks each candidate assembly with Mono.Cecil and applies `EliminateUnreachableInstructions` (removes dead IL the AOT linker chokes on) and `GenerateGenericWorkaroundMethods` (synthesises reachable instantiations of generic delegate helpers so IL2CPP's generic-sharing pass can find them).
@@ -34,10 +26,10 @@ Install exactly one variant. See [magic-unity-smoke](../unity-examples/magic-uni
 
 ## How it works
 
-1. You compile your own Clojure namespaces to `.clj.dll` outside Unity via `nos dotnet/build`, writing them into `Assets/Plugins/Magic/` (see [magic-unity-smoke/dotnet.clj](../unity-examples/magic-unity-smoke/dotnet.clj) for the canonical task definition). The package does not include a compiler.
+1. You compile your own Clojure namespaces outside Unity with `nos build`, writing them into `Assets/Plugins/Magic/`. A `.clj` source becomes `foo.clj.dll`, a `.cljc` becomes `foo.cljc.dll` and a `.cljr` becomes `foo.cljr.dll`; the Editor hooks below match all three. A project needing build steps the built-in task does not cover writes its own instead, as [magic-unity-smoke](../unity-examples/magic-unity-smoke/dotnet.clj) does.
 2. Unity opens the project. The prebuilt runtime + stdlib from `Runtime/Infrastructure/Export/` and your own `.clj.dll`s are both loaded as plain .NET assemblies. `Magic.Unity.Clojure.Boot()` initialises the runtime; `Require` / `GetVar` let C# scripts call into Clojure.
 3. On every build, `MagicPreprocessor` runs first. When the build target uses IL2CPP, it rewrites the `.clj.dll` bodies in place so the IL2CPP transpiler can consume them (and writes `link.xml` entries); on a Mono build the preprocessor only sweeps any leftover IL2CPP-only workarounds from a previous build. The runtime DLLs are loaded the same way under either backend.
-4. Coexistence with stock ClojureCLR: if a strong-named `Clojure.dll` is found under `Assets` (projects that keep ClojureCLR for Editor work and MAGIC for shipped builds), every MAGIC-compiled `.clj.dll` is imported with Editor loading off, because the stock runtime probe-loads `clojure.core.clj` at init and a MAGIC DLL answering that probe fails to load. With this default variant the runtime ships Editor-loadable, so on an immutable (PackageCache) install the Editor logs `Assembly '...clj.dll' will not be loaded due to errors: Assembly is incompatible with the editor` for the package's `Export` DLLs on every domain reload. These lines are benign (Unity reporting the intended exclusion, not a failure), and player builds are unaffected. To silence them, use the [`.dual` variant](#package-variants), which ships the runtime excluded from the Editor by construction.
+4. Coexistence with ClojureCLR: if a strong-named `Clojure.dll` is found under `Assets` (projects that keep ClojureCLR for Editor work and MAGIC for shipped builds), every MAGIC-compiled assembly is imported with Editor loading off. The reason is assembly enumeration order: ClojureCLR resolves a namespace by scanning the loaded assemblies for a `<ns>__Init` type and taking the first match, so a MAGIC `.clj.dll` sitting in the Editor domain can answer for a `clojure.*` namespace, and its answer throws. Keeping them out of the domain, rather than off the filesystem, is what fixes it. With this default variant the runtime ships Editor-loadable, so on an immutable (PackageCache) install the Editor logs `Assembly '...clj.dll' will not be loaded due to errors: Assembly is incompatible with the editor` for the package's `Export` DLLs on every domain reload. These lines are benign (Unity reporting the intended exclusion, not a failure), and player builds are unaffected. To silence them, use the [`.dual` variant](#package-variants), which ships the runtime excluded from the Editor by construction.
 
 ## Package variants
 
@@ -46,11 +38,11 @@ The package is shipped in two variants. They are identical except for one thing:
 | | `sg.flybot.magic.unity` (default) | `sg.flybot.magic.unity.dual` |
 |---|---|---|
 | Runtime in the Editor | yes (loadable) | no (`!UNITY_EDITOR`) |
-| MAGIC in Editor Play mode | works | not available (use stock ClojureCLR) |
-| Stock ClojureCLR alongside | probe clash, handled by the coexistence guard, with benign console noise | no clash, no noise (runtime is simply absent from the Editor) |
+| MAGIC in Editor Play mode | works | not available (use ClojureCLR) |
+| ClojureCLR alongside | probe clash, handled by the coexistence guard, with benign console noise | no clash, no noise (runtime is simply absent from the Editor) |
 | Player builds (Mono / IL2CPP) | identical | identical |
 
-Choose the **default** if your project runs MAGIC in the Editor (Play mode, edit-mode tooling) and has no stock ClojureCLR. Choose **`.dual`** if your Editor runs stock ClojureCLR (REPL / hot-reload) and MAGIC only ships in player builds: the runtime is excluded from the Editor by the define constraint, so Unity never attempts to load it there and prints no narration.
+Choose the **default** if your project runs MAGIC in the Editor (Play mode, edit-mode tooling) and has no ClojureCLR. Choose **`.dual`** if your Editor runs ClojureCLR (REPL / hot-reload) and MAGIC only ships in player builds: the runtime is excluded from the Editor by the define constraint, so Unity never attempts to load it there and prints no narration.
 
 `magic-unity-dual/` is generated from `magic-unity/` by `bb gen-unity-dual` (the DLLs are byte-identical copies; only the 37 runtime `.meta`s and the package name differ) and is kept in sync by `bb check-drift`. The in-repo coexistence repro that validates both variants is `magic-unity-coexist/` (`bb coexist-noise` for the dual variant, `bb coexist-noise magic-only` to reproduce the noise).
 
@@ -65,4 +57,7 @@ Choose the **default** if your project runs MAGIC in the Editor (Play mode, edit
 
 ## Legal
 
-Copyright © 2020 Ramsey Nasser and contributors. Licensed under the Apache License, Version 2.0.
+Copyright © 2020-2023 Ramsey Nasser and contributors.
+Copyright © 2026 Flybot Pte. Ltd.
+
+Licensed under the Apache License, Version 2.0.

--- a/nostrand/NostrandMain.csproj
+++ b/nostrand/NostrandMain.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="Scripts/nos-core" Link="nos" CopyToOutputDirectory="PreserveNewest" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <Content Include="Scripts/nos-core" Link="nos" CopyToOutputDirectory="PreserveNewest" Condition="'$(TargetFramework)' == 'net6.0'" />
     <Content Include="Scripts/nos-framework" Link="nos" CopyToOutputDirectory="PreserveNewest" Condition="'$(TargetFramework)' == 'net471'" />
     <Content Include="nostrand/**/*.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Mono.Terminal" Version="5.4.2" />
-    <PackageReference Include="Lokad.ILPack" Version="0.1.5" Condition="'$(TargetFramework)' == 'net5.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nostrand/README.md
+++ b/nostrand/README.md
@@ -1,5 +1,7 @@
 # Nostrand
-Standalone runtime environment and REPL for ClojureCLR on Mono. Bundled in the [flybot-sg/magic](https://github.com/flybot-sg/magic) monorepo as the task runner that hosts the MAGIC compiler.
+Standalone runtime environment and REPL for Clojure on the CLR. Bundled in the [flybot-sg/magic](https://github.com/flybot-sg/magic) monorepo as the host that boots the runtime, loads the MAGIC compiler, and runs your tasks.
+
+This page is the reference for the parts specific to nostrand: how it runs a function, and how it resolves dependencies. For the task surface a project actually uses, `nos build`, `nos test` and `magic.edn`, see [the `nos` CLI](../docs/nos-cli.md).
 
 ## Install
 
@@ -35,6 +37,7 @@ Nostrand <version>
 Clojure.Runtime <version>
 Magic.Runtime <version>
 Clojure 1.10.0-master-SNAPSHOT
+Runtime 4.0.30319.42000 (Unix 25.5.0.0)
 
 $ nos repl
 user=>
@@ -60,7 +63,7 @@ $ cat tasks.clj
 $ nos tasks/build
 ```
 
-Command line arguments are parsed as EDN passed to the function.
+Command line arguments are read as EDN and passed to the function. The whole command line is read at once, so a form may span several shell words; when that fails to read, `nos` retries argument by argument and passes anything still unreadable through as a symbol, which is what lets a filesystem path be an argument.
 
 ```clojure
 $ cat tasks.clj
@@ -75,7 +78,7 @@ $ cat tasks.clj
 $ nos tasks/build true
 ```
 
-Your entry namespace can also set up your classpath, load assemblies, and eventually manage dependencies.  
+Your entry namespace can also set up your load path and load assemblies before its own `ns` form runs.
 
 ```clojure
 $ cat tasks.clj
@@ -93,8 +96,10 @@ $ cat tasks.clj
 $ nos tasks/build true
 ```
 
-### `deps.edn`
-If a `deps.edn` is present in the current directory it is resolved at startup: every dependency is fetched and its source paths, plus the project's own `:paths`, are pushed onto the load path. The recognized keys are a subset of [tools.deps](https://github.com/clojure/tools.deps):
+### The deps file
+Nostrand reads `deps-clr.edn` from the current directory when it is there, and `deps.edn` otherwise, matching what `cljr` does. Whichever it reads is resolved at startup: every dependency is fetched and its source paths, plus the project's own `:paths`, are pushed onto the load path. Which of the two to write is [Declaring CLR dependencies](../docs/clr-dependency-files.md).
+
+The recognized keys are a subset of [tools.deps](https://github.com/clojure/tools.deps):
 
 * `:paths` A vector of source paths. Defaults to `["src"]`.
 * `:deps` A map of `lib -> coordinate` (see [Dependencies](#dependencies)).
@@ -106,25 +111,18 @@ Inspect the resolved basis without compiling with `nos print-basis [:alias ...]`
 
 ### Dependencies
 
-Nostrand resolves git and local coordinates. Maven is not resolved natively, and libraries that ship inside `Clojure.dll` (`org.clojure/clojure`, `org.clojure/spec.alpha`, `org.clojure/core.specs.alpha`) are skipped. Resolution is transitive: each dependency's own `deps.edn` `:deps` are followed, with the coordinate closest to the root winning on conflict.
+Nostrand resolves git and local coordinates. Maven is not resolved natively, and the three libraries the runtime provides (`org.clojure/clojure`, `org.clojure/spec.alpha`, `org.clojure/core.specs.alpha`) are dropped by name. Resolution is transitive, and each dependency is read the same way the root project is, its own `deps-clr.edn` in preference to its `deps.edn`, with the coordinate closest to the root winning on conflict.
 
 #### Git
 
-A git coordinate is cloned over its URL's transport into a content-addressed cache under `$GITLIBS` if set, else `~/.nostrand/gitlibs`, checked out at the pinned commit, and verified against the pin. Private repositories authenticate through your git and SSH config, so no tokens live in `deps.edn`.
-
-`GITLIBS` is the same variable JVM tools.deps honours, so one setting relocates both caches (useful in CI, where the cache must live inside the checkout). The two tools cannot collide inside a shared directory: tools.deps writes under `_repos/` and `libs/`, nostrand under `nostrand/<host>/<group>/<repo>/<ref>/`. Use an absolute path; a relative one resolves against the directory `nos` runs from.
-
-Pin a `:git/sha`: a cache whose checkout does not match the sha is an error, which is what makes a build reproducible. A `:git/tag` may accompany the sha as a readable label (its commit is checked against the sha, warning on a mismatch). A tag on its own is honoured but only warns if the tag later moves, so prefer a sha.
+A git coordinate is cloned into a content-addressed cache (`$GITLIBS/nostrand` when `GITLIBS` is set, else `~/.nostrand/gitlibs`), checked out at the pinned commit, and verified against the pin. Private repositories authenticate through your git and SSH config, so no tokens live in `deps.edn`.
 
 ```clojure
 {:deps {flybot-sg/clr.test.check {:git/url "https://github.com/flybot-sg/clr.test.check"
-                                  :git/sha "a5a2aca27873539fe366c1e0a09bb06e36026bf6"}
-        some/private-lib         {:git/url "git@dev.example.sg:group/private-lib.git"
-                                  :git/tag "v1.2.0"
-                                  :git/sha "1c3decbb9b6f9b2a0e0e6a4f0b1c2d3e4f5a6b7c"}}}
+                                  :git/sha "a5a2aca27873539fe366c1e0a09bb06e36026bf6"}}}
 ```
 
-A coordinate may carry an explicit `:paths` vector, used in place of the dependency's own `deps.edn` `:paths`, for a repo that has no `deps.edn` or a non-`src` layout (e.g. a contrib lib under `src/main/clojure`).
+Coordinates are read the way `tools.deps` and `cljr` read them. URL inference from the lib name, the legacy `:sha`/`:tag` spellings, `:deps/root`, `:exclusions`, conflict resolution and the coord `:paths` extension are all in [Declaring CLR dependencies](../docs/clr-dependency-files.md).
 
 #### Local
 
@@ -136,7 +134,7 @@ Used in place with no clone. This is also how you live-edit a dependency.
 
 #### Aliases
 
-A CLR build typically activates a `:clr` alias carrying the forks the JVM side does not need:
+A project that keeps one `deps.edn` for both runtimes puts the forks the JVM side does not need behind a `:clr` alias:
 
 ```clojure
 {:aliases   {:clr {:extra-deps    {clr-only/fork {:git/url "..." :git/sha "..."}}
@@ -152,24 +150,16 @@ A project that vendors its dependencies as git submodules can treat `.gitmodules
 
 ### Build and test tasks
 
-The built-in `nostrand.tasks` namespace ships shared `dotnet.clj` helpers so a project does not restate its build:
+`nos build` and `nos test` ship with the host, so most projects need no task file at all. Both derive the namespaces they work on by scanning the project's own source paths, and an optional `magic.edn` at the root states whatever differs from the defaults.
 
-* `compile-project` compiles the namespaces on the (alias-activated) source paths.
-* `run-clojure-tests` requires and runs `clojure.test` suites; `:re` scopes the run to matching namespaces.
-* `production-flags` is the `var->value` flag map shipped projects compile under (`*direct-linking*`, `*strongly-typed-invokes*`, ...).
-
-A project's own `dotnet.clj` calls these. See [Porting a Clojure library to MAGIC](../docs/porting-libraries-to-magic.md) for the full `dotnet.clj` shapes and the option reference.
+The pieces they are made of are public in `nostrand.tasks`, so a custom task composes them instead of restating them: `compile-project`, `run-clojure-tests`, `project-namespaces`, and the `production-flags` and `test-flags` maps. [The `nos` CLI](../docs/nos-cli.md) is the full reference for the tasks, the `magic.edn` keys, and the compiler flags each one binds.
 
 ## Name
-[Nostrand Avenue](https://en.wikipedia.org/wiki/Nostrand_Avenue) is a major street and subway stop in Brooklyn near where I was living when I began the project.
+[Nostrand Avenue](https://en.wikipedia.org/wiki/Nostrand_Avenue) is a major street and subway stop in Brooklyn near where Ramsey Nasser lived when he began the project.
 
 ## Legal
-Copyright © 2016-2017 Ramsey Nasser
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+Copyright © 2016-2023 Ramsey Nasser and contributors.
+Copyright © 2026 Flybot Pte. Ltd.
 
-```
-http://www.apache.org/licenses/LICENSE-2.0
-```
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+Licensed under the Apache License, Version 2.0.

--- a/nostrand/Scripts/nos-core
+++ b/nostrand/Scripts/nos-core
@@ -2,4 +2,4 @@
 ACTUAL_PATH=`dirname "$0"`
 LINKED_PATH=`readlink "$0"`
 ASSEMBLY_PATH=$([ "$LINKED_PATH" ] && echo `dirname "$LINKED_PATH"` || echo "$ACTUAL_PATH")
-dotnet $ASSEMBLY_PATH/Nostrand.dll "$@"
+dotnet $ASSEMBLY_PATH/NostrandMain.dll "$@"

--- a/unity-examples/magic-unity-coexist/Assets/Editor/CoexistenceProbe.cs
+++ b/unity-examples/magic-unity-coexist/Assets/Editor/CoexistenceProbe.cs
@@ -4,14 +4,19 @@ using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
-// Headless assertion helper for the coexistence repro. Reproduces the exact
-// init-time probe stock ClojureCLR's RT runs (Assembly.Load("clojure.core.clj"))
-// and reports the editor-domain state the #25 guard is responsible for.
+// Headless assertion helper for the coexistence repro. Reports the editor-domain
+// state the coexistence guard is responsible for.
+//
+// The Assembly.Load below is a canary, not a reproduction of what ClojureCLR
+// does: ClojureCLR resolves a namespace by scanning the loaded assemblies for a
+// <ns>__Init type and taking the first match, never by simple name. Both routes
+// need the same thing though, so resolving the fork clojure.core.clj here means
+// it is in the domain and can win that scan.
 //
 // In a correctly guarded coexisting editor the expected steady state is:
 //   preloaded-clj=0  core-clj-loadable=false  clojure-versions=[1.11.0.0]
 // i.e. the fork clj.dll plugins are excluded from the editor domain, so the
-// stock probe fails (the fork DLL is not there to answer it) and only stock
+// load fails (the fork DLL is not there to answer it) and only ClojureCLR
 // 1.11.0 wins the Clojure.dll dedup. If the guard regresses, the probe
 // resolves the fork clojure.core.clj and the TypeLoadException storm returns.
 //

--- a/unity-examples/magic-unity-coexist/README.md
+++ b/unity-examples/magic-unity-coexist/README.md
@@ -1,14 +1,14 @@
 # magic-unity-coexist
 
-A minimal Unity project that reproduces the **stock-ClojureCLR coexistence
-noise** in-repo, so the magic repository can validate fixes to that bug class
-without the private consumer project where it was first observed.
+A minimal Unity project that reproduces the **ClojureCLR coexistence noise**
+in-repo, so this repository can validate fixes to that bug class without the
+consumer project where it was first observed.
 
 ## What it reproduces
 
-On every editor open or domain reload, a consumer that keeps stock ClojureCLR
-in the editor (for REPL and hot-reload) while shipping the MAGIC fork runtime in
-player builds prints one ERROR line per package Export `*.clj.dll`:
+On every editor open or domain reload, a consumer that keeps ClojureCLR in the
+editor (for REPL and hot-reload) while shipping the MAGIC fork runtime in player
+builds prints one ERROR line per package Export `*.clj.dll`:
 
 ```
 Assembly 'Packages/sg.flybot.magic.unity/Runtime/Infrastructure/Export/clojure.core_clr.clj.dll' will not be loaded due to errors:
@@ -17,22 +17,23 @@ Assembly is incompatible with the editor
 
 plus one benign `Duplicate assembly 'Clojure.dll'` dedup line. The baseline is
 one narration line per runtime `.clj.dll` in Export, currently **37**. They are
-benign: Unity is narrating the
-intended editor exclusion from issue #25, not a real failure. This project
-exists to make that narration measurable and to let a silencing patch prove it
-went to zero without regressing the exclusion.
+benign: Unity is narrating the intended editor exclusion, not a real failure.
+This project exists to make that narration measurable and to let a silencing
+patch prove it went to zero without regressing the exclusion.
 
 ## Why the noise happens (and why this setup is the only way to see it)
 
 Two ingredients are both required:
 
-1. **A foreign stock `Clojure.dll` under `Assets/`.** `StockClojureCoexistence`
+1. **A foreign ClojureCLR `Clojure.dll` under `Assets/`.** The coexistence guard
    scans the filesystem for a strong-named `Clojure.dll`; finding one flips
-   every fork `*.clj.dll` plugin to editor-loading-off (issue #25: stock
-   `RT` probe-loads `clojure.core.clj` at init and a fork DLL answering that
-   probe throws a `TypeLoadException` storm). This project vendors the exact
-   stock layout under `Assets/Plugins/clojure-clr/` (Clojure 1.11.0 net462 +
-   DLR 1.3.2 + spec packages), marked Editor-only, identical to the consumer.
+   every fork `*.clj.dll` plugin to editor-loading-off. The hazard is assembly
+   enumeration order, not a name probe: `Compiler.TryLoadInitType` walks
+   `AppDomain.CurrentDomain.GetAssemblies()` and takes the first one exposing a
+   `<ns>__Init` type, so a fork DLL in the editor domain can answer for a
+   `clojure.*` namespace and throw. This project vendors that layout under
+   `Assets/Plugins/clojure-clr/` (Clojure 1.11.0 net462 + DLR 1.3.2 + spec
+   packages), marked Editor-only, identical to a real consumer.
 
 2. **An immutable (PackageCache) install of the package.** The narration is a
    *mismatch*: Unity reads the shipped `.meta` (editor-compatible) to decide the
@@ -43,9 +44,8 @@ Two ingredients are both required:
    install) never shows this, and why `bb coexist-noise` installs the package
    from a repacked tarball, which Unity resolves into a read-only PackageCache.
 
-The standalone `magic-unity-smoke` project deliberately has no stock ClojureCLR,
-so it has no coexistence and never narrates. This project is its coexistence
-counterpart.
+The standalone `magic-unity-smoke` project deliberately has no ClojureCLR, so it
+has no coexistence and never narrates. This project is its counterpart.
 
 ## Running it
 
@@ -87,8 +87,8 @@ problem is present). Watch `~/Library/Logs/Unity/Editor.log` on a domain reload
 
 - **Dual variant** (`bb coexist-noise`): **0** narration lines, and the probe
   still reports `core-clj-loadable=false` with `preloaded-clj=0` (the runtime
-  `clj.dll`s stay out of the editor domain, so a stock `RT` init cannot resolve
-  them: issue #25 stays fixed). The `Duplicate assembly 'Clojure.dll'` dedup
+  `clj.dll`s stay out of the editor domain, so a ClojureCLR `RT` init cannot
+  resolve them, and the exclusion holds). The `Duplicate assembly 'Clojure.dll'` dedup
   line remains (benign, and confirms the package actually resolved). A run that
   reports 0 narration but no probe line is INCONCLUSIVE, not a pass: the package
   likely failed to resolve.

--- a/unity-examples/magic-unity-smoke/README.md
+++ b/unity-examples/magic-unity-smoke/README.md
@@ -34,11 +34,13 @@ One namespace per edge-case family. Each exports `(suite)` returning a vector of
 |-----------|-------:|-------|
 | `smoke.value-types`  | 9  | Zero-arity instance members on `Int64` / `Double` / `String`. Regression set for the constrained.callvirt fix. |
 | `smoke.letfn-cases`  | 3  | Mutually-recursive `letfn` and a closure case. Regression set for letfn closed-over field init. |
-| `smoke.polymorphism` | 19 | Protocols on `defrecord`/`deftype`, the auto-generated record collection surface (equiv/count/conj/assoc, incl. a zero-field record), reify-against-protocol, reify and proxy against `System.Object`, `proxy-super` (incl. the shadowed type-hinted `this` idiom), multimethods. |
-| `smoke.control-flow` | 10 | `loop`/`recur`, `try`/`catch`/`finally` (incl. nested try-finally with side-effecting finally + deref-in-catch), `lazy-seq`, basic numerics. |
+| `smoke.polymorphism` | 20 | Protocols on `defrecord`/`deftype`, the auto-generated record collection surface (equiv/count/conj/assoc, incl. a zero-field record), reify-against-protocol, reify and proxy against `System.Object`, `proxy-super` (incl. the shadowed type-hinted `this` idiom), protocol-hinted parameters, multimethods. |
+| `smoke.control-flow` | 18 | `loop`/`recur`, `try`/`catch`/`finally` (incl. nested try-finally with side-effecting finally + deref-in-catch), `lazy-seq`, branches that never return, `#inst` / `#uuid` constants, named fn self-reference, narrow numeric casts and integer promotion. |
+| `smoke.read-print`   | 12 | Floating point through the reader and the printer: out-of-range literals reading as infinity, and doubles and floats surviving `pr-str` then `read-string`. IL2CPP supplies its own `Double.ToString` and exception handling, so Mono does not cover this. |
 | `smoke.stdlib-1-10`  | 11 | Clojure 1.10 stdlib surface: `symbol`, `read+string`, `PrintWriter-on`, `tap>`, `Throwable->map`, ex-triage, extend-via-metadata. |
+| `smoke.interop`      | 2  | `by-ref` on a type-hinted local. Written as `.cljr`, so the source-extension handling is exercised too. |
 
-52 checks total. All green under Mono and Standalone Mac IL2CPP.
+75 checks total. All green under Mono and Standalone Mac IL2CPP.
 
 ## Adding a new edge case
 


### PR DESCRIPTION
- New guides: `docs/architecture.md`, `docs/bootstrap.md`, `docs/development.md`, `docs/nos-cli.md`.
- Rewritten guides: why-magic, deterministic compilation and the drift check, CLR dependency files, native assembly loading, porting, cross-platform Clojure, Unity integration.
- Each topic has one owning doc and the others link to it instead of restating it.
- Root and component READMEs follow one structure with uniform attribution blocks, keeping Ramsey Nasser's original tutorials and name etymologies.
- Tooling ride-along: `bb dev-compiler` runs two bootstrap passes, the MSBuild targets rebuild unconditionally, and `bb check-drift` drops its `skip-dlls` mode.
- `bb.edn` task docstrings are one sentence per line, scoped to what each task does.