### PR TITLE
docs(repo): adopt per-PR changelog entries and refresh the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,47 @@
 
 ## Unreleased
 
+### Compiler
+- `.cljr` files now load and compile. Reader conditionals are allowed only in `.cljc`, same as upstream - [#101](https://github.com/flybot-sg/magic/issues/101), [#106](https://github.com/flybot-sg/magic/issues/106).
+- A namespace resolves to `.cljr`, `.cljc`, or `.clj` in that order, and each compiles to and loads from its matching DLL (`foo.cljc` emits `foo.cljc.dll`) - [#116](https://github.com/flybot-sg/magic/issues/116).
+- A var with a registered intrinsic keeps its `:inline` expansion, so when the intrinsic declines the argument types the call still lowers through the inline to a static invocation, as on JVM Clojure and ClojureCLR, instead of falling back to a Var invoke. The `nth` intrinsic applies only at arity 2, so `(nth an-array i not-found)` keeps its bounds check - [#123](https://github.com/flybot-sg/magic/issues/123), [#129](https://github.com/flybot-sg/magic/issues/129).
+- Recompiling `magic.analyzer.intrinsics` no longer empties the intrinsics registry, so `clojure.walk` and 11 compiler namespaces compile with intrinsics again - [#119](https://github.com/flybot-sg/magic/issues/119).
+- A reader error surfaces instead of silently dropping the rest of the namespace; the read loop treated any exception as end of input. A top-level `nil` now compiles rather than ending the unit - [#104](https://github.com/flybot-sg/magic/issues/104).
+- A missing namespace reports the searched load-path candidates instead of `Loading from embedded resources is not supported` - [#102](https://github.com/flybot-sg/magic/issues/102).
+- A deferred `:import`, one whose type lives in a DLL that the same `ns` form's `:require` loads, no longer warns on stderr on every compile; the type resolves at runtime through `FindTypeOrThrow`, and the unloaded-DLL hint appears only when the import really fails - [#99](https://github.com/flybot-sg/magic/issues/99).
+
+### Runtime
+- Strings, symbols, and keywords compare by UTF-16 code unit instead of the machine's collation culture, so `compare` and `sort` order the same on every machine and match JVM Clojure - [#127](https://github.com/flybot-sg/magic/issues/127).
+- A double literal too large for `Double` reads as positive or negative infinity per its sign instead of throwing, like the JVM reader - [#111](https://github.com/flybot-sg/magic/issues/111).
+
+### Stdlib
+- Doubles print with round-trip precision and the invariant culture, so `pr` output reads back to the identical value, and a locale with a comma decimal separator no longer changes the printed form - [#112](https://github.com/flybot-sg/magic/issues/112).
+
+### Nostrand
+- `nos` arguments are read with the real `EdnReader` instead of a 2016 fork of it, so `##Inf`, `##NaN`, namespaced map literals, and digit-leading keywords like `:1` can be typed on the command line; bare filesystem paths still pass through unchanged - [#114](https://github.com/flybot-sg/magic/issues/114).
+- `nos` accepts the coordinate shorthands `clr.tools.deps` accepts and resolves them identically: inferred `:git/url`, legacy `:sha` and `:tag`, `:deps/root`, `:local/root` relative to its deps file, `:exclusions`. Unknown alias keys warn - [#109](https://github.com/flybot-sg/magic/issues/109).
+- A dependency's `deps-clr.edn` is preferred over its `deps.edn`, `:deps` included, so a library declaring CLR-only paths there contributes them transitively and its assembly directory reaches `CLOJURE_LOAD_PATH` - [#107](https://github.com/flybot-sg/magic/issues/107).
+- Running a `.cljc` file directly finds its `-main`; the extension was stripped by substring, so `runme.cljc` was looked up as namespace `runmec` - [#103](https://github.com/flybot-sg/magic/issues/103).
+
 ### Unity
-
-`sg.flybot.magic.unity` now ships **both** Clojure runtimes, and the `MAGIC_RUNTIME_IN_EDITOR` scripting define symbol decides which one the **Editor** loads: unset (the default), ClojureCLR; set, MAGIC. Player builds always run MAGIC and are identical either way; ClojureCLR-as-default is the only polarity Unity's constraint grammar can express - [#120](https://github.com/flybot-sg/magic/issues/120).
-
-Upgrading does not break existing projects: a project that kept ClojureCLR in the Editor gets exactly that by default. Coming from `sg.flybot.magic.unity.dual` (retired, along with `bb gen-unity-dual`), repin to `?path=magic-unity#<tag>` and set nothing. To run MAGIC in the Editor, set the symbol from `Project Settings > MAGIC` or `Magic.Unity.EditorRuntime.UseMagic()`. Delete any ClojureCLR `Clojure.dll` you vendored under `Assets`; an unconstrained copy overrides the selection.
-
-- The package vendors ClojureCLR 1.11.0 (net462) plus the DLR under `Runtime/clojure-clr/`, Editor-only, with EPL-1.0 / Apache-2.0 notices.
-- Both Editor states are silent: no `Assembly is incompatible with the editor` narration, no `Duplicate assembly 'Clojure.dll'` line.
-- Your own compiled `*.clj.dll` under `Assets` get the constraint applied on import, so they follow the Editor runtime.
-- When the constraint lands on assemblies the running Editor had already seen unconstrained - a cold start on stale metas, or upgrading to this package version - the package requests a script reload and the session converges in place. The first load's `Unloading broken assembly` lines stay in the Console.
-- `StockClojureCoexistence` is removed; it reacted to filesystem state and could override the runtime you asked for. The constraints subsume it.
-- The default state needs API Compatibility Level `.NET Framework`; the package warns and `Project Settings > MAGIC` offers a fix button.
+- `sg.flybot.magic.unity` now ships **both** Clojure runtimes on the **Editor**. When the `MAGIC_RUNTIME_IN_EDITOR` scripting define symbol is unset (the default), it loads ClojureCLR. When it is set (via `Project Settings > MAGIC`), it loads MAGIC. **Player** builds always run MAGIC and are identical either way.
+- ClojureCLR 1.11.0 plus the DLR is shipped as Editor-only with its EPL-1.0 / Apache-2.0 notices, both Editor states load without console noise, and compiled DLLs under `Assets` automatically get the same constraint as the package's MAGIC DLLs, so they follow the Editor runtime. `StockClojureCoexistence` is removed; the constraints subsume it. The default state needs API Compatibility Level `.NET Framework`; the settings page warns and offers a fix - [#120](https://github.com/flybot-sg/magic/issues/120).
+- `sg.flybot.magic.unity.dual` and `bb gen-unity-dual` are retired; the runtime-selection constraint covers both Editor states in the one package.
+- The editor import hooks recognize `.cljc.dll` and `.cljr.dll` compiled assemblies, not just `.clj.dll` - [#116](https://github.com/flybot-sg/magic/issues/116).
 
 ### Tooling
-- `bb coexist-noise` asserts both Editor runtime states (`clojure-clr` / `magic`, or both by default), the upgrade path, and the toggle round-trip, replacing the dual-variant noise count.
-- New `bb sync-clojure-clr` vendors a [`flybot-sg/clojure-clr`](https://github.com/flybot-sg/clojure-clr) release into the package; `bb write-metas` creates missing constrained `.meta`s.
+- New `bb sync-clojure-clr` downloads a [`flybot-sg/clojure-clr`](https://github.com/flybot-sg/clojure-clr) release into the package. `bb write-metas` creates missing constrained `.meta`s.
 - `bb check-drift` (and `bb write-metas`) fails if any shipped DLL loses its runtime-selection constraint.
-- `bb verify-dist` is reduced to the `nos version` smoke test; its file-existence checks duplicated what runtime boot and `bb check-drift` already fail on.
+- `bb verify-dist` is reduced to the `nos version` smoke test.
+- A failing `bb refresh-stdlib` or `bb test` exits non-zero, so CI actually fails on them; if any namespace fails to compile, no DLL is copied into `references/` - [#122](https://github.com/flybot-sg/magic/issues/122).
+- Refresh owns every stdlib namespace outside the `clojure.core` family: `clojure.string`, `clojure.set`, and `clojure.walk` move out of the bootstrap set, and `bb check-drift` byte-verifies 28 stdlib DLLs instead of 25 - [#119](https://github.com/flybot-sg/magic/issues/119).
+- `bb dev-compiler` runs both bootstrap passes, since only the second is the self-hosting fixpoint, and the MSBuild entry points rebuild the host after a C# edit instead of keeping a stale one. `bb check-drift`'s `skip-dlls` mode is removed.
+
+### Docs
+- New guides: architecture, bootstrap, development, and the `nos` CLI.
+- The topic docs are rewritten with one owner per topic, cross-linked instead of restated.
+- Root and component READMEs share one structure and keep Ramsey Nasser's original tutorials.
+- Runtime import failure and the loader namespace as the portable contract are documented - [#99](https://github.com/flybot-sg/magic/issues/99).
 
 ## v0.11.0 - 2026-07-24
 
@@ -27,7 +50,7 @@ Mostly compiler fixes: never-returning branches emitted invalid IL, protocol-hin
 
 ### Compiler
 - `if`/`cond` forms whose branches never return (throw or recur on both sides) no longer emit a dead branch past the end of the method, which the CLR rejected with a `VerificationException`. Constant-test ifs, like `cond`'s `(if :else expr nil)` expansion, are analyzed correctly too - [#54](https://github.com/flybot-sg/magic/issues/54).
-- A parameter hinted with a protocol name stays `Object` and dispatches through the protocol fn, as stock Clojure does. The hint used to narrow to the protocol's generated interface, so passing an `extend` / `extend-protocol` type threw `InvalidCastException` at the invoke boundary. A qualified tag, which is what `deftype` / `reify` specs expand to, still narrows - [#51](https://github.com/flybot-sg/magic/issues/51).
+- A parameter hinted with a protocol name stays `Object` and dispatches through the protocol fn, as upstream Clojure does. The hint used to narrow to the protocol's generated interface, so passing an `extend` / `extend-protocol` type threw `InvalidCastException` at the invoke boundary. A qualified tag, which is what `deftype` / `reify` specs expand to, still narrows - [#51](https://github.com/flybot-sg/magic/issues/51).
 - A named fn's self-reference is the fn value itself, so `identical?` / `=` between them returns true, matching JVM and ClojureCLR. Reader source-location metadata is stripped from fn literals like upstream, so `(meta (fn [] 1))` is `nil` - [#52](https://github.com/flybot-sg/magic/issues/52), [#53](https://github.com/flybot-sg/magic/issues/53).
 - When a type fails to resolve, the error hints at load-path DLLs matching the type's namespace prefix that are not loaded yet - [#70](https://github.com/flybot-sg/magic/issues/70).
 - Reporting a wrong-arity instance-method call no longer throws an `ArityException` from the error reporter itself, masking the diagnostic - [#79](https://github.com/flybot-sg/magic/issues/79).
@@ -46,7 +69,7 @@ Mostly compiler fixes: never-returning branches emitted invalid IL, protocol-hin
 
 ### Nostrand
 - New `nos where` prints the directory of the runtime the running host actually loaded - [#72](https://github.com/flybot-sg/magic/issues/72).
-- `CLOJURE_LOAD_PATH` entries are absolute, so a loader scanning it finds native assemblies from any working directory, as on stock ClojureCLR - [#62](https://github.com/flybot-sg/magic/issues/62).
+- `CLOJURE_LOAD_PATH` entries are absolute, so a loader scanning it finds native assemblies from any working directory, as on ClojureCLR - [#62](https://github.com/flybot-sg/magic/issues/62).
 - A `deps.edn` without `:aliases` no longer throws a `NullReferenceException` when aliases are requested, undeclared aliases warn on stderr like tools.deps does, and a missing or malformed deps file is reported by name - [#55](https://github.com/flybot-sg/magic/issues/55).
 - `nos test` can skip individual `deftest` vars via `:exclude-vars` in `magic.edn`'s `:test` config, not just whole namespaces, so a lib with a few platform-specific tests still runs the rest - [#96](https://github.com/flybot-sg/magic/issues/96).
 
@@ -109,7 +132,7 @@ Compiler and runtime correctness fixes, plus CI coverage for the committed boots
 - `Compiler.InvokeInitType` initializes each assembly's init type at most once. A stray re-init of an already-loaded namespace no longer re-runs its top-level forms (which reset `*load-paths*` and cascaded into sub-namespace reloads). Reloading an already-initialized, DLL-backed namespace via `:reload` is now a no-op; source reload and freshly recompiled DLLs are unaffected - [#3](https://github.com/flybot-sg/magic/issues/3).
 
 ### Magic.Unity
-- `BootMagicRuntime` warns when a fork `Clojure.dll` is loaded but an expected bootstrap member is missing (the package scripts and `Clojure.dll` are mismatched MAGIC versions), instead of silently skipping the runtime bootstrap. It stays silent under stock ClojureCLR, so coexistence editors and hot-reload setups see nothing.
+- `BootMagicRuntime` warns when a fork `Clojure.dll` is loaded but an expected bootstrap member is missing (the package scripts and `Clojure.dll` are mismatched MAGIC versions), instead of silently skipping the runtime bootstrap. It does not warn under ClojureCLR, so coexistence editors and hot-reload setups see nothing.
 - Dropped the obsolete NuGet packaging from the package.
 
 ### Tooling
@@ -120,7 +143,7 @@ Compiler and runtime correctness fixes, plus CI coverage for the committed boots
 
 ## v0.7.0 - 2026-06-09
 
-A second Unity package variant for projects that keep stock ClojureCLR as the editor runtime.
+A second Unity package variant for projects that keep ClojureCLR as the editor runtime.
 
 ### Magic.Unity
 - New `sg.flybot.magic.unity.dual` variant: the runtime `*.clj.dll` carry a `!UNITY_EDITOR` define constraint, so Unity excludes them from the editor and a coexistence project no longer logs the `Assembly is incompatible with the editor` lines on every domain reload. The default `sg.flybot.magic.unity` is unchanged and still runs MAGIC in editor Play mode - [#30](https://github.com/flybot-sg/magic/issues/30).
@@ -131,13 +154,13 @@ A second Unity package variant for projects that keep stock ClojureCLR as the ed
 
 ## v0.6.0 - 2026-06-07
 
-Stock-ClojureCLR coexistence for Unity consumers that keep ClojureCLR as the editor runtime, plus IL2CPP workaround-selection fixes.
+ClojureCLR coexistence for Unity consumers that keep it as the editor runtime, plus IL2CPP workaround-selection fixes.
 
 ### Compiler
 - `set!` on a hinted mutable deftype field emits a `castclass`, fixing unverifiable IL that IL2CPP's transpiler rejects - [#27](https://github.com/flybot-sg/magic/issues/27).
 
 ### Magic.Unity
-- Coexistence: while a strong-named `Clojure.dll` is under `Assets`, fork `.clj.dll` plugins are excluded from the editor (and restored when it leaves), keeping stock RT's `clojure.core.clj` probe away from fork assemblies - [#25](https://github.com/flybot-sg/magic/issues/25). Editor scripts compile against the stock assembly in that state - [#24](https://github.com/flybot-sg/magic/issues/24).
+- Coexistence: while a strong-named `Clojure.dll` is under `Assets`, fork `.clj.dll` plugins are excluded from the editor (and restored when it leaves), keeping ClojureCLR RT's `clojure.core.clj` probe away from fork assemblies - [#25](https://github.com/flybot-sg/magic/issues/25). Editor scripts compile against ClojureCLR's assembly in that state - [#24](https://github.com/flybot-sg/magic/issues/24).
 - IL2CPP workaround signatures come from player compilation references instead of an editor AppDomain scan, keeping editor-only assemblies (e.g. `Mono.WebBrowser` on Windows) out of the signature pool - [#23](https://github.com/flybot-sg/magic/issues/23).
 - The workaround resolver searches project-local player reference directories - [#26](https://github.com/flybot-sg/magic/issues/26).
 - `csc.rsp` `-r:` references count as player references and are logged for build-log verification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,10 @@ Keep it to one line.
 
 Reference the issue with `Closes #<n>` in the description so GitHub closes it when the PR merges into `develop` (the default branch). Keep bullets short; the issue carries the full context.
 
+### Changelog entry
+
+A PR with a user-facing change adds an entry to the `## Unreleased` section of [CHANGELOG.md](./CHANGELOG.md), in the same PR, while the context is fresh. Describe the change as a user experiences it, the old symptom and the new behavior rather than the implementation, in one or two sentences ending with the issue link; match the style of the released sections. Internal refactors and test-only changes need no entry. At release time the section becomes the new version heading and gets an editing pass, so entries need to be accurate, not polished.
+
 ### Before opening one
 
 Run the local gate first; CI runs the same drift check and tests:
@@ -81,6 +85,8 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
     <prefix>(<scope>): <description>
 
 Common prefixes: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`. Keep the title to one line; details belong in the PR description.
+
+Keep the body to a few plain sentences: the what and the non-obvious why. Do not list the files touched, narrate the steps taken, or report test results; the diff and CI already show those. LLM-generated messages tend to include all three, so trim them before committing.
 
 Reference the related GitHub issue in the title or body, e.g. `(#42)` or `Closes #42`. Issue references belong in commit messages and PR descriptions only, never in source files or comments: trackers migrate, and in-code numbers go stale.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Using MAGIC on your own library:
 - [Declaring CLR dependencies](./docs/clr-dependency-files.md): `deps-clr.edn` vs a `:clr` alias, when the CLR needs different deps than the JVM.
 - [The `nos` CLI](./docs/nos-cli.md): how a task is found, `nos build` and `nos test`, and the `magic.edn` surface.
 - [Loading precompiled native assemblies](./docs/native-assemblies.md): loading a committed C# DLL on the CLR, where `:import` alone does not.
-- [Unity integration](./docs/unity-integration.md): compile `.clj.dll` and load them in a Unity project.
+- [Unity integration](./docs/unity-integration.md): compile Clojure to plugin DLLs and load them in a Unity project.
 
 Working on MAGIC itself:
 

--- a/docs/nos-cli.md
+++ b/docs/nos-cli.md
@@ -71,7 +71,7 @@ Note the following:
 
 - **`:re`** is matched with `re-matches`, so it has to match a namespace name whole. Write it as a string, since EDN has no regex literal: `"my\\.lib\\..*"`.
 - **`:exclude-vars`** takes fully-qualified `deftest` symbols. After `require`, the run clears the `:test` metadata on each, so `clojure.test` skips exactly those vars and the rest of their namespace still runs. It is for a handful of platform-specific failures scattered through otherwise-passing namespaces, where excluding the namespace would throw away good tests. A symbol that does not resolve warns rather than failing.
-- **`:namespaces`** is the escape hatch for what the derivation cannot see: a single compile root, or a vendored namespace no `require` reaches.
+- **`:namespaces`** is the escape hatch for what the derivation cannot see: a single compile root, or a namespace bundled in the repo that no `require` reaches.
 
 ## Compiler flags
 

--- a/docs/unity-integration.md
+++ b/docs/unity-integration.md
@@ -1,8 +1,8 @@
 # Unity integration
 
-How to use MAGIC in a Unity project: compile your Clojure to `.clj.dll` with the `nos` CLI outside Unity, then load it at play time through the `magic-unity` UPM package. The package also rewrites MAGIC's IL during IL2CPP builds (iOS, Android, consoles).
+How to use MAGIC in a Unity project: compile your Clojure to plugin DLLs with the `nos` CLI outside Unity, then load them at play time through the `magic-unity` UPM package. The package also rewrites MAGIC's IL during IL2CPP builds (iOS, Android, consoles).
 
-This is the consumer-side guide. For the package's C# API and install reference, see [magic-unity/README.md](../magic-unity/README.md). For the `deps.edn` / `magic.edn` compile workflow in depth, see [Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md).
+This is the consumer-side guide. For the package's C# API and install reference, see [magic-unity/README.md](../magic-unity/README.md). For the compile workflow in depth, see [Porting a Clojure library to MAGIC](./porting-libraries-to-magic.md).
 
 ## Steps
 
@@ -18,7 +18,7 @@ This is the consumer-side guide. For the package's C# API and install reference,
    }
    ```
 
-3. **Add `deps.edn` and `magic.edn`** at your project root. `deps.edn` declares your source `:paths` and any `:deps`; `magic.edn` points the build at Unity's plugins folder:
+3. **Add `deps-clr.edn` and `magic.edn`** at your project root. `deps-clr.edn` declares your source `:paths` and any `:deps` (see [declaring CLR dependencies](./clr-dependency-files.md)); `magic.edn` points the build at Unity's plugins folder:
 
    ```clojure
    ;; magic.edn
@@ -33,7 +33,7 @@ This is the consumer-side guide. For the package's C# API and install reference,
    nos build
    ```
 
-   This drops your `.clj.dll` into `Assets/Plugins/Magic/`, where Unity loads them.
+   This drops your compiled DLLs into `Assets/Plugins/Magic/`, named by the source extension (`.clj.dll`, `.cljc.dll`, `.cljr.dll`), where Unity loads them.
 
 5. **Write a loader, then Play.** Unity doesn't know which DLLs are Clojure or which var is the entry point, so a `MonoBehaviour` has to require and invoke it (pattern: [`SmokeTestRunner.cs`](../unity-examples/magic-unity-smoke/Assets/Scripts/SmokeTestRunner.cs)):
 
@@ -54,18 +54,38 @@ This is the consumer-side guide. For the package's C# API and install reference,
 
 The package ships both MAGIC (the default for the player build) and ClojureCLR (the default for the Unity editor); set the Editor runtime via `Project Settings > MAGIC`, or from a script through `Magic.Unity.EditorRuntime` ([package README](../magic-unity/README.md#editor-api)). ClojureCLR is the default because it hot-reloads from source; MAGIC-in-Editor is for reproducing player behaviour before a build.
 
+The `MAGIC_RUNTIME_IN_EDITOR` scripting define symbol leaves exactly one runtime present in every state:
+
+|                                 | MAGIC    | ClojureCLR |
+| ------------------------------- | -------- | ---------- |
+| Editor, symbol unset (default)  | excluded | included   |
+| Editor, symbol set              | included | excluded   |
+| Player, either                  | included | excluded   |
+
 Note that:
 
 - **API Compatibility Level must be `.NET Framework`** (`Project Settings > Player`) for ClojureCLR, as it needs assemblies the .NET Standard profile lacks.
-- In the default state, `Clojure.Require`/`GetVar` drive ClojureCLR, not MAGIC: the same C# calls, executed by whichever runtime the Editor loaded. ClojureCLR compiles from source, so Editor `Require` needs your `.clj` sources on its load path (`CLOJURE_LOAD_PATH`); the `.clj.dll` that `nos build` wrote are MAGIC output and stay excluded from the Editor in this state.
+- In the default state, `Clojure.Require`/`GetVar` drive ClojureCLR, not MAGIC: the same C# calls, executed by whichever runtime the Editor loaded. ClojureCLR compiles from source, so Editor `Require` needs your Clojure sources on its load path (`CLOJURE_LOAD_PATH`); the DLLs that `nos build` wrote are MAGIC output and stay excluded from the Editor in this state.
 
 ## Shipping your own compiled DLLs
 
-Your compiled `.clj.dll` / `.cljc.dll` / `.cljr.dll` need the same define constraint as the package's MAGIC DLLs. Otherwise, the DLL stays Editor-eligible even if the MAGIC runtime is excluded from the Editor.
+Your compiled `.clj.dll` / `.cljc.dll` / `.cljr.dll` need the same define constraint as the package's MAGIC DLLs; without it a DLL stays Editor-eligible even when the MAGIC runtime is excluded. You normally do nothing about this: for DLLs under `Assets/` and in embedded or local packages, the package applies the constraint itself, through two mechanisms. An **import** callback constrains each DLL as it arrives, and a **reconcile** pass sweeps every plugin after each domain reload. The pass is what covers DLLs that were already imported when this package version arrived: installing a package does not dirty `Assets/`, so the import callback never re-runs for them.
 
-Packages of your own that resolve into the immutable `Library/PackageCache` (registry, git, or tarball deps) need the constraint baked into the `.meta` at publish time.
+```mermaid
+flowchart TD
+    f["A DLL appears or changes<br/>e.g. nos build output"] --> pre["Import callback<br/>looks at that one file"]
+    c["Domain reload<br/>editor opens, a script changes,<br/>a package is installed"] --> rec["Reconcile<br/>looks at every plugin"]
+    pre --> gate{"A compiled Clojure DLL<br/>missing the constraint?"}
+    rec --> gate
+    gate -->|"under Assets/, or an<br/>embedded/local package"| add["Append the constraint"]
+    gate -->|"immutable package<br/>(Library/PackageCache)"| warn["Warn: the constraint<br/>must ship in the package"]
+    gate -->|"already constrained,<br/>or not a Clojure DLL"| skip["Leave it"]
+```
 
-For both pre-existing and newly-installed DLLs under `Assets/**` and in embedded or local packages, the package attempts to apply the constraint for you automatically. When the constraint lands on a DLL for the first time on a pre-existing DLL, the Editor reloads the DLL after the constraint. However, there may be some error lines from this first load depending on your Console configuration. These error lines will not reappear on subsequent loads.
+> [!NOTE]
+> The constraint is appended, never replacing what is already there, so a constraint you set yourself keeps holding (Unity ANDs the entries). When that happens on a DLL the Editor had already loaded, the package requests a script reload and the session converges in place; that first load can print error lines that do not reappear later.
+
+The one case that needs action from you is a DLL inside a package that resolves into the immutable `Library/PackageCache` (registry, git, or tarball deps): Unity discards `.meta` writes there, so the constraint has to ship in that package's `.meta` at publish time. The Editor warns and names the assemblies it could not constrain.
 
 ## Examples
 

--- a/magic-compiler/src/magic/old.clj
+++ b/magic-compiler/src/magic/old.clj
@@ -321,7 +321,7 @@
      (load-constant symname)
      (il/call (find-method RT "var" String String))]))
 
-;; NOTE the stock compiler looks up types using RT.classForName
+;; NOTE the ClojureCLR compiler looks up types using RT.classForName
 ;; if the type is not a valuetype. why? does it make a difference?
 (defn load-type [v]
   [(il/ldtoken v)

--- a/magic-unity/README.md
+++ b/magic-unity/README.md
@@ -6,7 +6,7 @@ This file is the developer reference. For the full usage guide about using with 
 
 This UPM package lets a Unity game run Clojure, in the Editor and in a shipped player on every backend Unity supports, IL2CPP included (iOS, Android, consoles). It ships two Clojure runtimes (MAGIC and ClojureCLR), a small C# API for calling into Clojure, and the Editor build hooks that make MAGIC's IL survive AOT compilation.
 
-It does not compile Clojure. Namespaces are compiled to `.clj.dll` outside Unity with `nos build`, and Unity loads them as plain .NET assemblies; see [step 4 of the guide](https://github.com/flybot-sg/magic/blob/main/docs/unity-integration.md#steps).
+It does not compile Clojure. Namespaces are compiled to plugin DLLs outside Unity with `nos build`, and Unity loads them as plain .NET assemblies; see [step 4 of the guide](https://github.com/flybot-sg/magic/blob/main/docs/unity-integration.md#steps).
 
 ## Install
 

--- a/nostrand/README.md
+++ b/nostrand/README.md
@@ -146,7 +146,7 @@ A project that keeps one `deps.edn` for both runtimes puts the forks the JVM sid
 
 #### Submodule paths
 
-A project that vendors its dependencies as git submodules can treat `.gitmodules` as the single source of truth for its `:paths`. Set `:nos/submodule-paths` to a path prefix (or `true` for every submodule) and boot derives the source paths from the checked-out submodules. Preview the derived list with `nos gitmodules-paths [prefix]`.
+A project that pins its dependencies as git submodules can treat `.gitmodules` as the single source of truth for its `:paths`. Set `:nos/submodule-paths` to a path prefix (or `true` for every submodule) and boot derives the source paths from the checked-out submodules. Preview the derived list with `nos gitmodules-paths [prefix]`.
 
 ### Build and test tasks
 

--- a/nostrand/nostrand/core.clj
+++ b/nostrand/nostrand/core.clj
@@ -28,7 +28,7 @@
 (defn update-load-path []
   (let [abs-paths (mapv #(System.IO.Path/GetFullPath %) @-load-path)]
     ;; CLOJURE_LOAD_PATH gets absolute roots (like *load-paths*), so a loader
-    ;; scanning it finds files from any cwd, matching stock ClojureCLR.
+    ;; scanning it finds files from any cwd, matching ClojureCLR.
     (Environment/SetEnvironmentVariable
       "CLOJURE_LOAD_PATH"
       (string/join Path/PathSeparator abs-paths))


### PR DESCRIPTION
---

- `CONTRIBUTING.md` now asks user-facing PRs to add their entry to the `## Unreleased` section of `CHANGELOG.md` in the same PR,
- Backfilled `CHANGELOG.md` for the ongoing release.
- Improve `docs/unity-integration.md` 
- Fix stale phrasing in doc