### PR TITLE
fix(nostrand): prefer a submodule's deps-clr.edn when deriving paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Nostrand
+- `:nos/submodule-paths` reads each submodule's `deps-clr.edn` when there is one, so a library can leave `deps.edn` to the JVM and declare its CLR paths in `deps-clr.edn`. A submodule without one keeps taking its `deps.edn` `:paths` - [#137](https://github.com/flybot-sg/magic/issues/137).
+
 ### Unity
 - The Editor loads ClojureCLR 1.11.0-flybot3, which fixes `sort` and `compare` ordering, so it orders values the way MAGIC does - [clojure-1.11.0-flybot3](https://github.com/flybot-sg/clojure-clr/releases/tag/clojure-1.11.0-flybot3).
 - Upgrading a project from `sg.flybot.magic.unity.dual` restores editor loading on the compiled DLLs it had excluded from the Editor, so `require` finds them again instead of failing with `Could not locate ...` on a namespace whose DLL is present - [#134](https://github.com/flybot-sg/magic/issues/134).

--- a/nostrand/nostrand/deps/submodules.clj
+++ b/nostrand/nostrand/deps/submodules.clj
@@ -29,15 +29,25 @@
         [])
        (filterv :path)))
 
+(defn- deps-file
+  "The submodule's deps file: deps-clr.edn when it has one, else deps.edn.
+  Same preference basis.clj applies to a dependency and cljr to a project, so
+  a library that keeps deps.edn for the JVM still contributes its CLR paths."
+  [sub-path]
+  (let [clr (str sub-path "/deps-clr.edn")
+        std (str sub-path "/deps.edn")]
+    (cond (File/Exists clr) clr
+          (File/Exists std) std)))
+
 (defn- src-dirs
   "Repo-relative source dirs a submodule at sub-path contributes. Prefer the
-  submodule's own deps.edn :paths; else whichever conventional source layouts
-  are present on disk; else [\"src\"]."
+  :paths of the submodule's own deps file; else whichever conventional source
+  layouts are present on disk; else [\"src\"]."
   [sub-path]
-  (let [deps-file (str sub-path "/deps.edn")
-        declared  (when (File/Exists deps-file)
-                    (try (:paths (edn/read-string (slurp deps-file)))
-                         (catch Exception _ nil)))]
+  (let [file     (deps-file sub-path)
+        declared (when file
+                   (try (:paths (edn/read-string (slurp file)))
+                        (catch Exception _ nil)))]
     (if declared
       (mapv #(str sub-path "/" %) declared)
       (let [present (filterv #(Directory/Exists (str sub-path "/" %))


### PR DESCRIPTION
Closes #137
---

- `:nos/submodule-paths` selects a submodule's `deps-clr.edn` over its `deps.edn`
- A submodule with neither keeps the existing on-disk fallback
